### PR TITLE
Simplification de la méthode isChunkClaimed avec getCityFromChunk

### DIFF
--- a/src/main/java/fr/openmc/core/features/city/CityManager.java
+++ b/src/main/java/fr/openmc/core/features/city/CityManager.java
@@ -73,27 +73,7 @@ public class CityManager {
     }
 
     public static boolean isChunkClaimed(int x, int z) {
-        if (claimedChunks.containsKey(BlockVector2.at(x, z))) {
-            return claimedChunks.get(BlockVector2.at(x, z)) != null;
-        }
-
-        try {
-            PreparedStatement statement = DatabaseManager.getConnection().prepareStatement("SELECT city_uuid FROM city_regions WHERE x = ? AND z = ? LIMIT 1");
-            statement.setInt(1, x);
-            statement.setInt(2, z);
-            ResultSet rs = statement.executeQuery();
-
-            if (!rs.next()) {
-                claimedChunks.put(BlockVector2.at(x, z), null);
-                return false;
-            }
-
-            claimedChunks.put(BlockVector2.at(x, z), CityManager.getCity(rs.getString("city_uuid")));
-            return claimedChunks.get(BlockVector2.at(x, z)) != null;
-        } catch (SQLException e) {
-            e.printStackTrace();
-            return false;
-        }
+        return getCityFromChunk(x, z) != null;
     }
 
     @Nullable


### PR DESCRIPTION
## Pour que votre Pull Request soit accepté, il vous faut :
* Votre code suit-il le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md) ? :
* Votre code se compile-il en local ? :
* Avez-vous supprimez au maximum les imports non utilisé? :
* Fournissez un Profileur (/spark profiler) lorsque vous éxécuter vos commandes, méthodes :

## Decrivez vos changements
*Clairement et avec des screenshots si nécessaires*
### Description des changements :
- La logique de la méthode isChunkClaimed a été modifiée afin de simplifier son implémentation.
- Au lieu de vérifier si un chunk est réclamé via un accès direct à la carte claimedChunks, la méthode appelle désormais getCityFromChunk(x, z) pour déterminer si une ville est associée à ce chunk.
- Si getCityFromChunk retourne une ville non nulle, cela signifie que le chunk est réclamé, et la méthode retourne true. Sinon, elle retourne false.

### Objectif de la modification :
- Simplifier le code de la méthode isChunkClaimed en centralisant la logique dans getCityFromChunk.
- Rendre le code plus lisible et maintenable en réduisant les duplications de code.

### Impact :
- Aucun changement majeur dans le comportement du système. La méthode fonctionne de la même manière, mais avec une implémentation plus claire.
- Cela facilite également la gestion des chunks réclamés, car la logique est maintenant déléguée à une méthode déjà existante (getCityFromChunk).