### PR TITLE
fix: if server started before 2AM, interest would be skipped that day + /wiki

### DIFF
--- a/src/main/java/fr/openmc/core/commands/utils/Socials.java
+++ b/src/main/java/fr/openmc/core/commands/utils/Socials.java
@@ -63,4 +63,14 @@ public class Socials {
                 OMCPlugin.getConfigs().getString("blog", "INVALID CONFIG")
         ));
     }
+
+    @Command("wiki")
+    @CommandPermission("omc.commands.wiki")
+    @Description("Donne le lien du wiki")
+    private void blog(CommandSender sender) {
+        sender.sendMessage(parseText(
+                "Lisez des articles sur ",
+                OMCPlugin.getConfigs().getString("wiki", "INVALID CONFIG")
+        ));
+    }
 }

--- a/src/main/java/fr/openmc/core/commands/utils/Socials.java
+++ b/src/main/java/fr/openmc/core/commands/utils/Socials.java
@@ -67,7 +67,7 @@ public class Socials {
     @Command("wiki")
     @CommandPermission("omc.commands.wiki")
     @Description("Donne le lien du wiki")
-    private void blog(CommandSender sender) {
+    private void wiki(CommandSender sender) {
         sender.sendMessage(parseText(
                 "Lisez des articles sur ",
                 OMCPlugin.getConfigs().getString("wiki", "INVALID CONFIG")

--- a/src/main/java/fr/openmc/core/features/economy/BankManager.java
+++ b/src/main/java/fr/openmc/core/features/economy/BankManager.java
@@ -198,10 +198,18 @@ public class BankManager {
 
     private void updateInterestTimer() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime nextMonday = now.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
-        LocalDateTime nextThursday = now.with(TemporalAdjusters.next(DayOfWeek.THURSDAY));
+
+        LocalDateTime nextMonday = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY)).withHour(2).withMinute(0).withSecond(0);
+        // if it is after 2 AM, get the monday after
+        if (nextMonday.isBefore(now))
+            nextMonday = nextMonday.with(TemporalAdjusters.next(DayOfWeek.MONDAY)).withHour(2).withMinute(0).withSecond(0);
+
+        LocalDateTime nextThursday = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.THURSDAY)).withHour(2).withMinute(0).withSecond(0);
+        // if it is after 2 AM, get the thursday after
+        if (nextThursday.isBefore(now))
+            nextThursday = nextThursday.with(TemporalAdjusters.next(DayOfWeek.THURSDAY)).withHour(2).withMinute(0).withSecond(0);
+
         LocalDateTime nextInterestUpdate = nextMonday.isBefore(nextThursday) ? nextMonday : nextThursday;
-        nextInterestUpdate = nextInterestUpdate.withHour(2).withMinute(2).withSecond(2);
         
         long secondsUntilUpdate = ChronoUnit.SECONDS.between(now, nextInterestUpdate);
         long ticksUntilUpdate = secondsUntilUpdate * 20; // there are 20 ticks in a second

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,3 +16,4 @@ features:
 homepage: "https://openmc.fr/"
 discord: "https://discord.gg/aywen/"
 blog: "https://blog.openmc.fr/"
+wiki: "https://wiki.openmc.fr/"


### PR DESCRIPTION
## Pour que votre Pull Request soit accepté, il vous faut :
* Votre code suit-il le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md) ? : oui
* Avez-vous supprimé au maximum les imports non utilisés ? : oui 
* Fournissez un Profileur (/spark profiler) lorsque vous éxécuter vos commandes, méthodes :

* Les Issues corrigé(e)s/en commun : 

## Decrivez vos changements

Le système d'intérèt prenait le prochain le Lundi ou le Jeudi le plus proche donc si le système était lancé un Lundi ou un Jeudi avant 2h du matin (lors d'un redémarrage de nuit par exemple), les intérèts seraient sautés.

Ajout du /wiki
