### PR TITLE
Fix bug de la quête "le randonneur"

### DIFF
--- a/src/main/java/fr/openmc/core/features/quests/quests/WalkQuests.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/WalkQuests.java
@@ -4,6 +4,7 @@ import fr.openmc.core.features.quests.objects.Quest;
 import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -22,13 +23,15 @@ public class WalkQuests extends Quest implements Listener {
 
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
         if (
             (event.getFrom().getBlockX() != event.getTo().getBlockX()
             || event.getFrom().getBlockZ() != event.getTo().getBlockZ())
-            && !event.getPlayer().isFlying()
-            && !event.getPlayer().isGliding()
+            && !player.isFlying()
+            && !player.isGliding()
+            && !player.isInsideVehicle()
         ) {
-            this.incrementProgress(event.getPlayer().getUniqueId());
+            this.incrementProgress(player.getUniqueId());
         }
     }
 }


### PR DESCRIPTION
## Pour que votre Pull Request soit accepté, il vous faut :
* Votre code suit-il le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md) ? : Oui
* Avez-vous supprimé au maximum les imports non utilisés ? : Oui
* Avez-vous commentez vos méthodes pour une meilleure lisibilité ? : Pas nécessaire je pense ?
* Fournissez un Profileur (/spark profiler) lorsque vous éxécuter vos commandes, méthodes : 

* Les Issues corrigé(e)s/en commun : 
#304

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->
La quête du randonneur était comptée si le joueur bougeait en bateau ou sur une monture, la quête vérifie maintenant si le joueur est sur un véhicule
