### PR TITLE
Fix les quests dans les regions worldguard

### DIFF
--- a/src/main/java/fr/openmc/core/features/quests/quests/BreakDiamondQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/BreakDiamondQuest.java
@@ -5,6 +5,7 @@ import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 
@@ -24,7 +25,7 @@ public class BreakDiamondQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerBreak(BlockBreakEvent event) {
         if (event.getBlock().getType().equals(Material.DIAMOND_ORE)
                 || event.getBlock().getType().equals(Material.DEEPSLATE_DIAMOND_ORE)

--- a/src/main/java/fr/openmc/core/features/quests/quests/BreakStoneQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/BreakStoneQuest.java
@@ -6,6 +6,7 @@ import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
@@ -24,7 +25,7 @@ public class BreakStoneQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerBreak(BlockBreakEvent event) {
         Block block = event.getBlock();
         if (block.getType().equals(Material.STONE)) {

--- a/src/main/java/fr/openmc/core/features/quests/quests/CityCreateQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/CityCreateQuest.java
@@ -9,6 +9,7 @@ import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 public class CityCreateQuest extends Quest implements Listener {
@@ -26,13 +27,13 @@ public class CityCreateQuest extends Quest implements Listener {
         ));
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onCityCreate(CityCreationEvent event) {
         Player player = event.getOwner();
         if (player != null) this.incrementProgress(player.getUniqueId());
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerJoin(MemberJoinEvent event) {
         OfflinePlayer player = event.getPlayer();
         if (player.isOnline()) this.incrementProgress(player.getUniqueId());

--- a/src/main/java/fr/openmc/core/features/quests/quests/ConsumeKebabQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/ConsumeKebabQuest.java
@@ -5,6 +5,7 @@ import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import fr.openmc.core.utils.customitems.CustomItemRegistry;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.ItemStack;
@@ -22,10 +23,10 @@ public class ConsumeKebabQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerConsume(PlayerItemConsumeEvent event) {
         ItemStack item = event.getItem();
-        if (item != null && item.isSimilar(CustomItemRegistry.getByName("omc_foods:kebab").getBest())) {
+        if (item.isSimilar(CustomItemRegistry.getByName("omc_foods:kebab").getBest())) {
             this.incrementProgress(event.getPlayer().getUniqueId());
         }
     }

--- a/src/main/java/fr/openmc/core/features/quests/quests/CraftCakeQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/CraftCakeQuest.java
@@ -5,6 +5,7 @@ import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.CraftItemEvent;
 
@@ -19,7 +20,7 @@ public class CraftCakeQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerCraft(CraftItemEvent event) {
         if (event.getRecipe().getResult().getType().equals(Material.CAKE)) {
             this.incrementProgress(event.getWhoClicked().getUniqueId());

--- a/src/main/java/fr/openmc/core/features/quests/quests/CraftDiamondArmorQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/CraftDiamondArmorQuest.java
@@ -6,6 +6,7 @@ import fr.openmc.core.features.quests.rewards.QuestItemReward;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.inventory.ItemStack;
@@ -35,7 +36,7 @@ public class CraftDiamondArmorQuest extends Quest implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onCraftItem(CraftItemEvent event) {
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;

--- a/src/main/java/fr/openmc/core/features/quests/quests/CraftKebabQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/CraftKebabQuest.java
@@ -7,6 +7,7 @@ import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import fr.openmc.core.utils.customitems.CustomItemRegistry;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.inventory.ItemStack;
@@ -28,7 +29,7 @@ public class CraftKebabQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerCraft(CraftItemEvent event) {
         ItemStack item = event.getCurrentItem();
         if (item != null && item.isSimilar(CustomItemRegistry.getByName("omc_foods:kebab").getBest())) {

--- a/src/main/java/fr/openmc/core/features/quests/quests/EnchantFirstItemQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/EnchantFirstItemQuest.java
@@ -5,6 +5,7 @@ import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.inventory.ItemStack;
@@ -19,10 +20,10 @@ public class EnchantFirstItemQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEnchantItem(EnchantItemEvent event) {
         ItemStack item = event.getItem();
-        if (item != null && item.getType() != Material.AIR) {
+        if (item.getType() != Material.AIR) {
             this.incrementProgress(event.getEnchanter().getUniqueId());
         }
     }

--- a/src/main/java/fr/openmc/core/features/quests/quests/KillPlayersQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/KillPlayersQuest.java
@@ -6,6 +6,7 @@ import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
@@ -25,7 +26,7 @@ public class KillPlayersQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerKill(PlayerDeathEvent event) {
         if (event.getEntity().getKiller() instanceof Player player) {
             this.incrementProgress(player.getUniqueId(), 1);

--- a/src/main/java/fr/openmc/core/features/quests/quests/KillSuperCreeperQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/KillSuperCreeperQuest.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 
@@ -22,7 +23,7 @@ public class KillSuperCreeperQuest extends Quest implements Listener {
         this.addTier(new QuestTier(1, new QuestMoneyReward(1000)));
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerKill(EntityDeathEvent event) {
         Player player = event.getEntity().getKiller();
         if (player != null && event.getEntity() instanceof Creeper creeper && creeper.isPowered()) {

--- a/src/main/java/fr/openmc/core/features/quests/quests/KillZombieQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/KillZombieQuest.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Zombie;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 
@@ -22,7 +23,7 @@ public class KillZombieQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onZombieKill(EntityDeathEvent event) {
         if (event.getEntity().getKiller() instanceof Player player && event.getEntity() instanceof Zombie) {
             this.incrementProgress(player.getUniqueId());

--- a/src/main/java/fr/openmc/core/features/quests/quests/MineAyweniteQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/MineAyweniteQuest.java
@@ -7,7 +7,6 @@ import fr.openmc.core.features.quests.rewards.QuestItemReward;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import fr.openmc.core.utils.customitems.CustomItemRegistry;
 import org.bukkit.Material;
-import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;

--- a/src/main/java/fr/openmc/core/features/quests/quests/MineAyweniteQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/MineAyweniteQuest.java
@@ -9,6 +9,7 @@ import fr.openmc.core.utils.customitems.CustomItemRegistry;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 
@@ -24,7 +25,7 @@ public class MineAyweniteQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerBreakBlock(BlockBreakEvent event) {
         CustomBlock customBlock = CustomBlock.byAlreadyPlaced(event.getBlock());
         if (customBlock != null && customBlock.getNamespacedID() != null &&

--- a/src/main/java/fr/openmc/core/features/quests/quests/SaveTheEarthQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/SaveTheEarthQuest.java
@@ -5,6 +5,7 @@ import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestItemReward;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.StructureGrowEvent;
 
@@ -21,7 +22,7 @@ public class SaveTheEarthQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerBreak(StructureGrowEvent event) {
         if (event.getPlayer() != null)
             this.incrementProgress(event.getPlayer().getUniqueId());

--- a/src/main/java/fr/openmc/core/features/quests/quests/SmeltIronQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/SmeltIronQuest.java
@@ -5,6 +5,7 @@ import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.FurnaceExtractEvent;
 
@@ -20,7 +21,7 @@ public class SmeltIronQuest extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerSmelt(FurnaceExtractEvent event) {
         if (event.getItemType().equals(Material.IRON_INGOT)) {
             int amount = event.getItemAmount();

--- a/src/main/java/fr/openmc/core/features/quests/quests/WalkQuests.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/WalkQuests.java
@@ -6,6 +6,7 @@ import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 
@@ -21,7 +22,7 @@ public class WalkQuests extends Quest implements Listener {
         );
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
         if (


### PR DESCRIPTION
## Pour que votre Pull Request soit accepté, il vous faut :
* Votre code suit-il le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md) ? : Oui
* Avez-vous supprimé au maximum les imports non utilisés ? : Oui
* Avez-vous commentez vos méthodes pour une meilleure lisibilité ? : 
* Fournissez un Profileur (/spark profiler) lorsque vous éxécuter vos commandes, méthodes :

* Les Issues corrigé(e)s/en commun : 
#217 

## Decrivez vos changements
J'ai tout mis en priorité monitor et activé le ignoreCancelled comme ça si un plugin annule l'action (par exemple Worldguard), elle ne sera pas prise en compte dans l'avancée des quêtes
