### PR TITLE
Fix l'envoi double du message d'avertissement quand on clique sur un bloc

### DIFF
--- a/src/main/java/fr/openmc/core/features/city/listeners/ProtectionListener.java
+++ b/src/main/java/fr/openmc/core/features/city/listeners/ProtectionListener.java
@@ -99,20 +99,11 @@ public class ProtectionListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
-        EquipmentSlot hand = event.getHand();
 
-        if (hand == EquipmentSlot.OFF_HAND) {
-            if (event.getAction() == Action.RIGHT_CLICK_BLOCK || event.getAction() == Action.RIGHT_CLICK_AIR) {
-                Location loc = event.getClickedBlock() != null
-                        ? event.getClickedBlock().getLocation()
-                        : player.getLocation();
-                verify(player, event, loc);
-            }
+        if (event.getHand() != EquipmentSlot.HAND)
             return;
-        }
 
         ItemStack inHand = event.getItem();
-
 
         if (event.getAction() == Action.RIGHT_CLICK_AIR && inHand != null && inHand.getType().isEdible()) {
             return;

--- a/src/main/java/fr/openmc/core/features/city/listeners/ProtectionListener.java
+++ b/src/main/java/fr/openmc/core/features/city/listeners/ProtectionListener.java
@@ -9,7 +9,6 @@ import fr.openmc.core.utils.messages.MessageType;
 import fr.openmc.core.utils.messages.MessagesManager;
 import fr.openmc.core.utils.messages.Prefix;
 import net.kyori.adventure.text.Component;
-import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -30,7 +29,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 public class ProtectionListener implements Listener {
@@ -56,13 +54,14 @@ public class ProtectionListener implements Listener {
     }
 
     private void verify(Player player, Cancellable event, Location loc) {
-        if (player.getWorld() != Bukkit.getWorld("world")) return;
-        
-        City city = getCityByChunk(loc.getChunk()); // on regarde le claim ou l'action a été fait
-        City cityz = CityManager.getPlayerCity(player.getUniqueId()); // on regarde la city du membre
+        if (!player.getWorld().getName().equals("world")) return;
 
         Boolean canBypass = playerCanBypass.get(player.getUniqueId());
         if (canBypass != null && canBypass) return;
+
+        City city = getCityByChunk(loc.getChunk()); // on regarde le claim ou l'action a été fait
+        City cityz = CityManager.getPlayerCity(player.getUniqueId()); // on regarde la city du membre
+
         if (isMemberOf(city, player)) return;
         if (cityz!=null){
             String city_type = CityManager.getCityType(city.getUUID());
@@ -79,7 +78,7 @@ public class ProtectionListener implements Listener {
     }
 
     private void verify(Entity entity, Cancellable event, Location loc) {
-        if (entity.getWorld() != Bukkit.getWorld("world")) return;
+        if (!entity.getWorld().getName().equals("world")) return;
 
         City city = getCityByChunk(loc.getChunk()); // on regarde le claim ou l'action a été fait
         if (city == null || !"war".equals(CityManager.getCityType(city.getUUID())))
@@ -109,11 +108,9 @@ public class ProtectionListener implements Listener {
             return;
         }
 
-        if (event.getInteractionPoint() == null && event.getClickedBlock() == null) return;
-      
-        Location loc = event.getClickedBlock() != null ?
-                event.getClickedBlock().getLocation() :
-                event.getInteractionPoint().toLocation(event.getPlayer().getWorld());
+        if (event.getClickedBlock() == null) return;
+
+        Location loc = event.getClickedBlock().getLocation();
 
         if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
             if (inHand != null && inHand.getType().isEdible()) {
@@ -149,8 +146,11 @@ public class ProtectionListener implements Listener {
     public void onDamageEntity(EntityDamageByEntityEvent event) {
         if (!(event.getDamager() instanceof Player damager)) return;
 
-        if (MascotUtils.isMascot(event.getEntity())) return;
-        Location loc = event.getEntity().getLocation();
+        Entity entity = event.getEntity();
+        if ((entity instanceof Player)) return;
+        if (MascotUtils.isMascot(entity)) return;
+
+        Location loc = entity.getLocation();
         verify(damager, event, loc);
     }
 
@@ -158,9 +158,11 @@ public class ProtectionListener implements Listener {
     void onInteractAtEntity(PlayerInteractAtEntityEvent event) {
         if (event.getHand() != EquipmentSlot.HAND) return;
 
-        if (MascotUtils.isMascot(event.getRightClicked())) return;
+        Entity rightClicked = event.getRightClicked();
+        if ((rightClicked instanceof Player)) return;
+        if (MascotUtils.isMascot(rightClicked)) return;
 
-        verify(event.getPlayer(), event, event.getRightClicked().getLocation());
+        verify(event.getPlayer(), event, rightClicked.getLocation());
     }
 
     @EventHandler
@@ -267,10 +269,8 @@ public class ProtectionListener implements Listener {
 
     @EventHandler
     public void onHangingBreakByEntity(HangingBreakByEntityEvent event) {
-        if (event.getEntity() instanceof ItemFrame || event.getEntity() instanceof Painting) {
-            if (event.getRemover() instanceof Player player) {
-                verify(player, event, event.getEntity().getLocation());
-            }
+        if (event.getRemover() instanceof Player player) {
+            verify(player, event, event.getEntity().getLocation());
         }
     }
 
@@ -300,6 +300,8 @@ public class ProtectionListener implements Listener {
                 event.setCancelled(true);
                 return;
             }
+
+            return;
         }
 
         if (event.getDamager() instanceof Player damager) {


### PR DESCRIPTION
## Petit résumé de la PR:
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [x] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks

## Decrivez vos changements
Le message d'avertissement quand on cliquait sur un bloc était envoyé deux fois (HAND et OFF_HAND) donc on check uniquement pour les interactions avec la main HAND

https://github.com/user-attachments/assets/d7fdd86f-264a-4bd9-a9a9-bc9ba1aafa67