### PR TITLE
Ajout de l'affichage de la durée avant le prochaine intérêt

### DIFF
--- a/src/main/java/fr/openmc/core/features/city/menu/bank/CityBankMenu.java
+++ b/src/main/java/fr/openmc/core/features/city/menu/bank/CityBankMenu.java
@@ -7,10 +7,12 @@ import fr.openmc.core.features.city.CPermission;
 import fr.openmc.core.features.city.City;
 import fr.openmc.core.features.city.CityManager;
 import fr.openmc.core.features.city.menu.CityMenu;
+import fr.openmc.core.features.economy.BankManager;
 import fr.openmc.core.features.economy.EconomyManager;
 import fr.openmc.core.utils.messages.MessageType;
 import fr.openmc.core.utils.messages.MessagesManager;
 import fr.openmc.core.utils.messages.Prefix;
+import fr.openmc.core.utils.DateUtils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
@@ -83,7 +85,7 @@ public class CityBankMenu extends Menu {
                 itemMeta.itemName(Component.text("§6L'Argent de votre Ville"));
                 itemMeta.lore(List.of(
                        Component.text("§7La ville a actuellement §d" + EconomyManager.getFormattedSimplifiedNumber(city.getBalance()) + " ").append(Component.text(EconomyManager.getEconomyIcon()).decoration(TextDecoration.ITALIC, false)),
-                        Component.text("§7Votre prochain intéret est de §b" + city.calculateCityInterest()*100 + "%")
+                        Component.text("§7Votre prochain intéret est de §b" + city.calculateCityInterest()*100 + "% §7dans §b" + DateUtils.convertSecondToTime(BankManager.getInstance().getSecondsUntilInterest()))
                     )
                 );
             }));

--- a/src/main/java/fr/openmc/core/features/economy/BankManager.java
+++ b/src/main/java/fr/openmc/core/features/economy/BankManager.java
@@ -202,7 +202,7 @@ public class BankManager {
             OMCPlugin.getInstance().getLogger().info("Distribution des intérèts réussie.");
             updateInterestTimer();
 
-        }, getSecondsUntilUpdate() * 20); // 20 ticks per second (ideally)
+        }, getSecondsUntilInterest() * 20); // 20 ticks per second (ideally)
     }
 
     public long getSecondsUntilInterest() {

--- a/src/main/java/fr/openmc/core/features/economy/BankManager.java
+++ b/src/main/java/fr/openmc/core/features/economy/BankManager.java
@@ -195,8 +195,18 @@ public class BankManager {
     }
 
     private void updateInterestTimer() {
-        LocalDateTime now = LocalDateTime.now();
+        Bukkit.getScheduler().runTaskLater(OMCPlugin.getInstance(), () -> {
+            OMCPlugin.getInstance().getLogger().info("Distribution des intérèts...");
+            applyAllPlayerInterests();
+            CityManager.applyAllCityInterests();
+            OMCPlugin.getInstance().getLogger().info("Distribution des intérèts réussie.");
+            updateInterestTimer();
 
+        }, getSecondsUntilUpdate() * 20); // 20 ticks per second (ideally)
+    }
+
+    public long getSecondsUntilInterest() {
+        LocalDateTime now = LocalDateTime.now();
         LocalDateTime nextMonday = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY)).withHour(2).withMinute(0).withSecond(0);
         // if it is after 2 AM, get the monday after
         if (nextMonday.isBefore(now))
@@ -209,16 +219,6 @@ public class BankManager {
 
         LocalDateTime nextInterestUpdate = nextMonday.isBefore(nextThursday) ? nextMonday : nextThursday;
         
-        long secondsUntilUpdate = ChronoUnit.SECONDS.between(now, nextInterestUpdate);
-        long ticksUntilUpdate = secondsUntilUpdate * 20; // there are 20 ticks in a second
-
-        Bukkit.getScheduler().runTaskLater(OMCPlugin.getInstance(), () -> {
-            OMCPlugin.getInstance().getLogger().info("Distribution des intérèts...");
-            applyAllPlayerInterests();
-            CityManager.applyAllCityInterests();
-            OMCPlugin.getInstance().getLogger().info("Distribution des intérèts réussie.");
-            updateInterestTimer();
-
-        }, ticksUntilUpdate);
+        return ChronoUnit.SECONDS.between(now, nextInterestUpdate);
     }
 }

--- a/src/main/java/fr/openmc/core/features/economy/menu/PersonalBankMenu.java
+++ b/src/main/java/fr/openmc/core/features/economy/menu/PersonalBankMenu.java
@@ -61,7 +61,7 @@ public class PersonalBankMenu extends Menu {
                 Component.text("§7Vous avez actuellement §d" +
                         EconomyManager.getInstance().getFormattedSimplifiedNumber(BankManager.getInstance().getBankBalance(player.getUniqueId())) + " ")
                     .append(Component.text(EconomyManager.getEconomyIcon()).decoration(TextDecoration.ITALIC, false)),
-                Component.text("§7Votre prochain intéret est de §b" + BankManager.getInstance().calculatePlayerInterest(player.getUniqueId())*100 + "%")
+                Component.text("§7Votre prochain intéret est de §b" + BankManager.getInstance().calculatePlayerInterest(player.getUniqueId())*100 + "%")// §7dans §b" + DateUtils.)
                 )
             );
         }));

--- a/src/main/java/fr/openmc/core/features/economy/menu/PersonalBankMenu.java
+++ b/src/main/java/fr/openmc/core/features/economy/menu/PersonalBankMenu.java
@@ -5,6 +5,7 @@ import fr.openmc.api.menulib.utils.InventorySize;
 import fr.openmc.api.menulib.utils.ItemBuilder;
 import fr.openmc.core.features.economy.BankManager;
 import fr.openmc.core.features.economy.EconomyManager;
+import fr.openmc.core.utils.DateUtils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
@@ -61,7 +62,7 @@ public class PersonalBankMenu extends Menu {
                 Component.text("§7Vous avez actuellement §d" +
                         EconomyManager.getInstance().getFormattedSimplifiedNumber(BankManager.getInstance().getBankBalance(player.getUniqueId())) + " ")
                     .append(Component.text(EconomyManager.getEconomyIcon()).decoration(TextDecoration.ITALIC, false)),
-                Component.text("§7Votre prochain intéret est de §b" + BankManager.getInstance().calculatePlayerInterest(player.getUniqueId())*100 + "%")// §7dans §b" + DateUtils.)
+                Component.text("§7Votre prochain intéret est de §b" + BankManager.getInstance().calculatePlayerInterest(player.getUniqueId())*100 + "% §7dans §b" + DateUtils.convertSecondToTime(BankManager.getInstance().getSecondsUntilInterest()))
                 )
             );
         }));

--- a/src/main/java/fr/openmc/core/utils/DateUtils.java
+++ b/src/main/java/fr/openmc/core/utils/DateUtils.java
@@ -40,27 +40,28 @@ public class DateUtils {
         return String.format("%dj %dh %dm %ds", days, hours, minutes, seconds);
     }
 
-        public static String formatRelativeDate(LocalDateTime dateTime) {
-            LocalDateTime now = LocalDateTime.now();
-            Duration duration = Duration.between(dateTime, now);
-            long minutes = duration.toMinutes();
+    public static String formatRelativeDate(LocalDateTime dateTime) {
+        LocalDateTime now = LocalDateTime.now();
+        Duration duration = Duration.between(dateTime, now);
+        long minutes = duration.toMinutes();
 
-            String repetMsg="Il y a ";
-            if (minutes < 1) {
-                return "À l'instant";
-            } else if (minutes < 60) {
-                return repetMsg + minutes + " minute" + (minutes > 1 ? "s" : "");
-            } else if (duration.toHours() < 24) {
-                long hours = duration.toHours();
-                return repetMsg + hours + " heure" + (hours > 1 ? "s" : "");
-            } else if (duration.toDays() <= 5) {
-                long days = duration.toDays();
-                return repetMsg + days + " jour" + (days > 1 ? "s" : "");
-            } else {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("'Le' dd/MM/yyyy 'à' HH:mm");
-                return dateTime.format(formatter);
-            }
+        String repetMsg="Il y a ";
+        if (minutes < 1) {
+            return "À l'instant";
+        } else if (minutes < 60) {
+            return repetMsg + minutes + " minute" + (minutes > 1 ? "s" : "");
+        } else if (duration.toHours() < 24) {
+            long hours = duration.toHours();
+            return repetMsg + hours + " heure" + (hours > 1 ? "s" : "");
+        } else if (duration.toDays() <= 5) {
+            long days = duration.toDays();
+            return repetMsg + days + " jour" + (days > 1 ? "s" : "");
+        } else {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("'Le' dd/MM/yyyy 'à' HH:mm");
+            return dateTime.format(formatter);
         }
+    }
+
     public static String getTimeUntilNextMonday() {
         LocalDateTime now = LocalDateTime.now();
 


### PR DESCRIPTION
## Petit résumé de la PR:

Les menus des banques affichent maintenant le durée avant le prochaine intérêt

## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [x] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks

* Les Issues corrigée(s) en commun : Closes #364 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->

- Ajout de la fonction `secondsUntilInterest`
- Modification des lores des menus des banques
- Fix indentation dans `DateUtils`