### PR TITLE
Corrige une erreur critique lors de la sauvegarde des Shops

### DIFF
--- a/src/main/java/fr/openmc/core/features/corporation/manager/CompanyManager.java
+++ b/src/main/java/fr/openmc/core/features/corporation/manager/CompanyManager.java
@@ -446,34 +446,40 @@ public class CompanyManager {
                 PreparedStatement stmtShop = conn.prepareStatement(queryShop);
                 PreparedStatement stmtShopItem = conn.prepareStatement(queryShopItem)
         ) {
-            for (Map.Entry<UUID, Shop> entry : PlayerShopManager.getInstance().getPlayerShops().entrySet()) {
-                Shop shop = entry.getValue();
-                UUID shopUuid = shop.getUuid();
-                UUID owner = entry.getKey();
-                double x = shop.getBlocksManager().getMultiblock(shopUuid).getStockBlock().getBlockX();
-                double y = shop.getBlocksManager().getMultiblock(shopUuid).getStockBlock().getBlockY();
-                double z = shop.getBlocksManager().getMultiblock(shopUuid).getStockBlock().getBlockZ();
+            PlayerShopManager manager = PlayerShopManager.getInstance();
+            if (manager != null) {
+                Map<UUID, Shop> playerShops = manager.getPlayerShops();
+                if (playerShops != null) {
+                    for (Map.Entry<UUID, Shop> entry : playerShops.entrySet()) {
+                        Shop shop = entry.getValue();
+                        UUID shopUuid = shop.getUuid();
+                        UUID owner = entry.getKey();
+                        double x = shop.getBlocksManager().getMultiblock(shopUuid).getStockBlock().getBlockX();
+                        double y = shop.getBlocksManager().getMultiblock(shopUuid).getStockBlock().getBlockY();
+                        double z = shop.getBlocksManager().getMultiblock(shopUuid).getStockBlock().getBlockZ();
 
-                for (ShopItem shopItem : shop.getItems()) {
-                    byte[] item = shopItem.getItem().serializeAsBytes();
-                    double price = shopItem.getPricePerItem();
-                    int amount = shopItem.getAmount();
+                        for (ShopItem shopItem : shop.getItems()) {
+                            byte[] item = shopItem.getItem().serializeAsBytes();
+                            double price = shopItem.getPricePerItem();
+                            int amount = shopItem.getAmount();
 
-                    stmtShopItem.setBytes(1, item);
-                    stmtShopItem.setString(2, shopUuid.toString());
-                    stmtShopItem.setDouble(3, price);
-                    stmtShopItem.setInt(4, amount);
-                    stmtShopItem.addBatch();
+                            stmtShopItem.setBytes(1, item);
+                            stmtShopItem.setString(2, shopUuid.toString());
+                            stmtShopItem.setDouble(3, price);
+                            stmtShopItem.setInt(4, amount);
+                            stmtShopItem.addBatch();
+                        }
+
+                        stmtShop.setString(1, shopUuid.toString());
+                        stmtShop.setString(2, owner.toString());
+                        stmtShop.setString(3, null);
+                        stmtShop.setString(4, null);
+                        stmtShop.setDouble(5, x);
+                        stmtShop.setDouble(6, y);
+                        stmtShop.setDouble(7, z);
+                        stmtShop.addBatch();  // Adding shop to batch
+                    }
                 }
-
-                stmtShop.setString(1, shopUuid.toString());
-                stmtShop.setString(2, owner.toString());
-                stmtShop.setString(3, null);
-                stmtShop.setString(4, null);
-                stmtShop.setDouble(5, x);
-                stmtShop.setDouble(6, y);
-                stmtShop.setDouble(7, z);
-                stmtShop.addBatch();  // Adding shop to batch
             }
 
             stmtShop.executeBatch(); // Execute batch for shops


### PR DESCRIPTION
Ajoute des vérifications de nullité pour :
- L'instance PlayerShopManager
- La map playerShops

Évite le crash au enable du plugin.

## Petit résumé de la PR:


## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
* #443 

## Decrivez vos changements

```java
PlayerShopManager manager = PlayerShopManager.getInstance();
if (manager != null) {
    Map<UUID, Shop> playerShops = manager.getPlayerShops();
    if (playerShops != null) {
        for (Map.Entry<UUID, Shop> entry : playerShops.entrySet()) {
            // Code existant deja
        }
    }
}
```
