### PR TITLE
[FEAT] Ajoute une bossbar d'aide

### DIFF
--- a/src/main/java/fr/openmc/core/ListenersManager.java
+++ b/src/main/java/fr/openmc/core/ListenersManager.java
@@ -2,6 +2,7 @@ package fr.openmc.core;
 
 import fr.openmc.api.input.ChatInput;
 import fr.openmc.api.input.location.ItemInteraction;
+import fr.openmc.core.features.bossbar.listeners.BossbarListener;
 import fr.openmc.core.features.mailboxes.MailboxListener;
 import fr.openmc.core.features.updates.UpdateListener;
 import fr.openmc.core.listeners.*;
@@ -26,7 +27,8 @@ public class ListenersManager {
                 new RespawnListener(),
                 new SleepListener(),
                 new PlayerDeathListener(),
-                new AsyncChatListener(OMCPlugin.getInstance())
+                new AsyncChatListener(OMCPlugin.getInstance()),
+                new BossbarListener()
         );
     }
 

--- a/src/main/java/fr/openmc/core/OMCPlugin.java
+++ b/src/main/java/fr/openmc/core/OMCPlugin.java
@@ -6,6 +6,7 @@ import fr.openmc.api.menulib.MenuLib;
 import fr.openmc.core.commands.admin.freeze.FreezeManager;
 import fr.openmc.core.commands.utils.SpawnManager;
 import fr.openmc.core.features.adminshop.AdminShopManager;
+import fr.openmc.core.features.bossbar.BossbarManager;
 import fr.openmc.core.features.city.CityManager;
 import fr.openmc.core.features.city.mascots.MascotsManager;
 import fr.openmc.core.features.city.mayor.managers.MayorManager;
@@ -93,6 +94,7 @@ public class OMCPlugin extends JavaPlugin {
             new LeaderboardManager(this);
         new AdminShopManager(this);
         new AccountDetectionManager(this);
+        new BossbarManager(this);
 
         if (!OMCPlugin.isUnitTestVersion()){
             new ShopBlocksManager(this);

--- a/src/main/java/fr/openmc/core/features/bossbar/BossbarManager.java
+++ b/src/main/java/fr/openmc/core/features/bossbar/BossbarManager.java
@@ -1,0 +1,121 @@
+package fr.openmc.core.features.bossbar;
+
+import fr.openmc.core.CommandsManager;
+import fr.openmc.core.OMCPlugin;
+import fr.openmc.core.features.accountdetection.commands.AccountDetectionCommand;
+import fr.openmc.core.features.bossbar.commands.BossBarCommand;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import lombok.Getter;
+
+import java.io.File;
+import java.util.*;
+
+public class BossbarManager {
+    @Getter
+    private static BossbarManager instance;
+    private final Map<UUID, BossBar> activeBossBars = new HashMap<>();
+    private final List<Component> helpMessages = new ArrayList<>();
+    @Getter
+    private final File configFile;
+    private int currentMessageIndex = 0;
+    @Getter
+    private final OMCPlugin plugin;
+
+
+    public BossbarManager(OMCPlugin plugin) {
+        instance = this;
+        this.plugin = plugin;
+        this.configFile = new File(OMCPlugin.getInstance().getDataFolder() + "/data", "bossbars.yml");
+        loadConfig();
+        loadDefaultMessages();
+        startRotationTask();
+        CommandsManager.getHandler().register(new BossBarCommand());
+    }
+
+    private void loadConfig() {
+        if (!configFile.exists()) {
+            configFile.getParentFile().mkdirs();
+            OMCPlugin.getInstance().saveResource("data/bossbars.yml", false);
+        }
+        reloadMessages();
+    }
+
+    private void loadDefaultMessages() {
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(configFile);
+        helpMessages.clear();
+
+        for (String rawMessage : config.getStringList("messages")) {
+            helpMessages.add(MiniMessage.miniMessage().deserialize(rawMessage));
+        }
+
+        if (helpMessages.isEmpty()) {
+            plugin.getLogger().warning("Aucun message chargé - vérifiez bossbars.yml");
+        }
+    }
+
+    private void startRotationTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (helpMessages.isEmpty()) return;
+
+                currentMessageIndex = (currentMessageIndex + 1) % helpMessages.size();
+                Component message = helpMessages.get(currentMessageIndex);
+
+                activeBossBars.forEach((uuid, bossBar) -> {
+                    Player player = Bukkit.getPlayer(uuid);
+                    if (player != null) {
+                        bossBar.name(message);
+                    }
+                });
+            }
+        }.runTaskTimer(OMCPlugin.getInstance(), 0, 200); // Change toutes les 10 secondes (200 ticks)
+    }
+
+    public void addBossBar(Player player) {
+        if (activeBossBars.containsKey(player.getUniqueId())) return;
+
+        BossBar bossBar = BossBar.bossBar(
+                helpMessages.get(0),
+                1.0f,
+                BossBar.Color.PINK,
+                BossBar.Overlay.PROGRESS
+        );
+
+        player.showBossBar(bossBar);
+        activeBossBars.put(player.getUniqueId(), bossBar);
+    }
+
+    public void removeBossBar(Player player) {
+        BossBar bossBar = activeBossBars.remove(player.getUniqueId());
+        if (bossBar != null) {
+            player.hideBossBar(bossBar);
+        }
+    }
+
+    public void toggleBossBar(Player player) {
+        if (activeBossBars.containsKey(player.getUniqueId())) {
+            removeBossBar(player);
+            player.sendMessage(Component.text("Bossbar désactivée").color(NamedTextColor.RED));
+        } else {
+            addBossBar(player);
+            player.sendMessage(Component.text("Bossbar activée").color(NamedTextColor.GREEN));
+        }
+    }
+
+    public void reloadMessages() {
+        helpMessages.clear();
+        loadDefaultMessages();
+    }
+
+    public boolean hasBossBar(Player player) {
+        return activeBossBars.containsKey(player.getUniqueId());
+    }
+}

--- a/src/main/java/fr/openmc/core/features/bossbar/commands/BossBarCommand.java
+++ b/src/main/java/fr/openmc/core/features/bossbar/commands/BossBarCommand.java
@@ -1,0 +1,38 @@
+package fr.openmc.core.features.bossbar.commands;
+
+import fr.openmc.core.OMCPlugin;
+import fr.openmc.core.features.bossbar.BossbarManager;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.DefaultFor;
+import revxrsal.commands.annotation.Subcommand;
+import revxrsal.commands.bukkit.annotation.CommandPermission;
+
+@Command({"omcbossbar"})
+public class BossBarCommand {
+
+    @DefaultFor("~")
+    public void mainCommand(CommandSender sender) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("§cCette commande est réservée aux joueurs.");
+            return;
+        }
+
+        BossbarManager.getInstance().toggleBossBar(player);
+    }
+
+    @CommandPermission("omc.admin.commands.bossbar.reload")
+    @Subcommand("reload")
+    public void reloadCommand(CommandSender sender) {
+        BossbarManager.getInstance().reloadMessages();
+        sender.sendMessage("§aMessages de la bossbar rechargés.");
+    }
+
+    @CommandPermission("omc.admin.commands.bossbar.toggle")
+    @Subcommand("toggle")
+    public void toggleCommand(CommandSender sender, Player target) {
+        BossbarManager.getInstance().toggleBossBar(target);
+        sender.sendMessage("§aBossbar " + (BossbarManager.getInstance().hasBossBar(target) ? "activée" : "désactivée") + " pour " + target.getName());
+    }
+}

--- a/src/main/java/fr/openmc/core/features/bossbar/listeners/BossbarListener.java
+++ b/src/main/java/fr/openmc/core/features/bossbar/listeners/BossbarListener.java
@@ -1,0 +1,14 @@
+package fr.openmc.core.features.bossbar.listeners;
+
+import fr.openmc.core.features.bossbar.BossbarManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class BossbarListener implements Listener {
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        BossbarManager.getInstance().addBossBar(event.getPlayer());
+    }
+}

--- a/src/main/resources/data/bossbars.yml
+++ b/src/main/resources/data/bossbars.yml
@@ -1,0 +1,6 @@
+messages:
+  - "<bold><gold>Bienvenue sur <gradient:#ff77e9:#ff1493>OpenMC</gradient> !</gold></bold>"
+  - "<bold><aqua>Astuce :</aqua></bold> <white>Utilisez <green>/leaderboard</green> pour voir les <yellow>classements</yellow> !"
+  - "<bold><light_purple>Événement en cours :</light_purple></bold> <gradient:#ff416c:#ff4b2b>UPDATE V2 !</gradient>"
+  - "<bold><aqua>Astuce :</aqua></bold> <white>Utilisez <gradient:#ff77e9:#ff1493>/omcbossbar</gradient> pour activer/désactiver la <yellow>bossbar</yellow> !"
+  - "<blue>Rejoignez le <bold><aqua>discord</aqua></bold> pour contribuer au <green>développement</green> !"


### PR DESCRIPTION
Ajoute une bossbar qui affiche
des messages d'aides.

data/bossbar.yml pour ajouter/supprimer des messages d'aides.
UTILISE MiniMessage

Commandes :
- `/omcbossbar` Permet de activer/désactiver la bossbar.
- `/omcbossbar reload` (ADMIN) Permet de recharger les messages d'aides.
- `/omcbossbar toggle` "Joueur" (ADMIN) Permet de activer/désactiver la bossbar pour un joueur

## Petit résumé de la PR:


## Étape nécessaire afin que la PR soit fini (si PR en draft)

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [x] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
* #386 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->
![image](https://github.com/user-attachments/assets/b92bfe3d-2132-4b9b-8d2b-9a3d160aaebf)

