### PR TITLE
[FEAT] Ajoute la liason joueurs minecraft/discord

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ repositories {
     maven {
         url "https://jitpack.io" // Toujours à la fin
     }
+    maven {
+        url "https://m2.dv8tion.net/releases"
+    }
 }
 
 dependencies {
@@ -64,6 +67,7 @@ dependencies {
     implementation 'com.github.Revxrsal.Lamp:common:3.2.1'
     implementation 'com.github.Revxrsal.Lamp:bukkit:3.2.1'
     implementation 'net.raidstone:wgevents:1.18.1'
+    implementation "net.dv8tion:JDA:5.0.0-beta.20"
 
     compileOnly 'org.projectlombok:lombok:1.18.34'
     annotationProcessor 'org.projectlombok:lombok:1.18.34'

--- a/src/main/java/fr/openmc/core/CommandsManager.java
+++ b/src/main/java/fr/openmc/core/CommandsManager.java
@@ -8,6 +8,7 @@ import fr.openmc.core.commands.fun.Diceroll;
 import fr.openmc.core.commands.fun.Playtime;
 import fr.openmc.core.commands.utils.*;
 import fr.openmc.core.features.adminshop.AdminShopCommand;
+import fr.openmc.core.features.discordlink.commands.DiscordLinkCommand;
 import fr.openmc.core.features.friend.FriendCommand;
 import fr.openmc.core.features.friend.FriendManager;
 import fr.openmc.core.features.mailboxes.MailboxCommand;
@@ -47,7 +48,8 @@ public class CommandsManager {
                 new FriendCommand(),
                 new QuestCommand(),
                 new Restart(),
-                new AdminShopCommand()
+                new AdminShopCommand(),
+                new DiscordLinkCommand()
         );
     }
 

--- a/src/main/java/fr/openmc/core/OMCPlugin.java
+++ b/src/main/java/fr/openmc/core/OMCPlugin.java
@@ -14,6 +14,7 @@ import fr.openmc.core.features.contest.managers.ContestPlayerManager;
 import fr.openmc.core.features.corporation.manager.CompanyManager;
 import fr.openmc.core.features.corporation.manager.PlayerShopManager;
 import fr.openmc.core.features.corporation.manager.ShopBlocksManager;
+import fr.openmc.core.features.discordlink.DiscordLinkManager;
 import fr.openmc.core.features.economy.BankManager;
 import fr.openmc.core.features.economy.EconomyManager;
 import fr.openmc.core.features.friend.FriendManager;
@@ -93,6 +94,7 @@ public class OMCPlugin extends JavaPlugin {
             new LeaderboardManager(this);
         new AdminShopManager(this);
         new AccountDetectionManager(this);
+        new DiscordLinkManager(this);
 
         if (!OMCPlugin.isUnitTestVersion()){
             new ShopBlocksManager(this);

--- a/src/main/java/fr/openmc/core/features/discordlink/DiscordBot.java
+++ b/src/main/java/fr/openmc/core/features/discordlink/DiscordBot.java
@@ -1,0 +1,165 @@
+package fr.openmc.core.features.discordlink;
+
+import fr.openmc.core.OMCPlugin;
+import fr.openmc.core.utils.messages.MessageType;
+import fr.openmc.core.utils.messages.MessagesManager;
+import fr.openmc.core.utils.messages.Prefix;
+import lombok.Getter;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import javax.security.auth.login.LoginException;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public class DiscordBot extends ListenerAdapter {
+    private final OMCPlugin plugin;
+    private JDA jda;
+    @Getter
+    private static DiscordBot instance;
+
+    /**
+     * Constructs a new DiscordBot instance
+     * @param plugin The main plugin instance
+     */
+    public DiscordBot(OMCPlugin plugin) {
+        this.plugin = plugin;
+        instance = this;
+    }
+
+    /**
+     * Starts the Discord bot asynchronously
+     * Initializes JDA and registers event listeners
+     */
+    public void startBot() {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                jda = JDABuilder.createDefault(plugin.getConfig().getString("bot-discord.bot-token"))
+                        .enableIntents(GatewayIntent.MESSAGE_CONTENT)
+                        .addEventListeners(this)
+                        .build();
+
+                jda.awaitReady();
+
+                // Enregistrement des commandes slash
+                registerCommands();
+
+                plugin.getLogger().log(Level.INFO, "Bot Discord connecté avec succès!");
+            } catch (InterruptedException e) {
+                plugin.getLogger().log(Level.SEVERE, "Erreur lors du démarrage du bot Discord: " + e.getMessage());
+            }
+        });
+    }
+
+    /**
+     * Registers slash commands for the Discord bot
+     * Currently registers the /link command with a code parameter
+     */
+    private void registerCommands() {
+        Guild guild = jda.getGuildById(plugin.getConfig().getString("bot-discord.guild-id"));
+        if (guild != null) {
+            guild.updateCommands().addCommands(
+                    Commands.slash("link", "Lie ton compte Minecraft à Discord")
+                            .addOption(OptionType.STRING, "code", "Code de vérification", true)
+            ).queue();
+        }
+    }
+
+    /**
+     * Stops the Discord bot gracefully
+     */
+    public void stopBot() {
+        if (jda != null) {
+            jda.shutdown();
+        }
+    }
+
+    /**
+     * Handles slash command interactions
+     * @param event The slash command interaction event
+     */
+    @Override
+    public void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
+        if (event.getName().equals("link")) {
+            handleLinkCommand(event);
+        }
+    }
+
+    /**
+     * Processes the /link command from Discord
+     * @param event The slash command interaction event containing the verification code
+     */
+    private void handleLinkCommand(SlashCommandInteractionEvent event) {
+        String code = event.getOption("code").getAsString();
+        User user = event.getUser();
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            boolean success = DiscordLinkManager.getInstance().linkAccounts(code, user.getId()).join();
+
+            if (success) {
+                event.reply("✅ Ton compte Discord a bien été lié à ton compte Minecraft!")
+                        .setEphemeral(true)
+                        .queue();
+
+                // Notifier le joueur en jeu
+                String minecraftUUID = DiscordLinkManager.getInstance().getMinecraftUUID(user.getId()).join();
+                Player player = Bukkit.getPlayer(UUID.fromString(minecraftUUID));
+
+                if (player != null && player.isOnline()) {
+                    Bukkit.getScheduler().runTask(plugin, () -> {
+                        MessagesManager.sendMessage(player,
+                                Component.text("Ton compte a été lié avec succès à Discord: ")
+                                        .append(Component.text(user.getAsTag(), NamedTextColor.GREEN)),
+                                Prefix.DISCORD, MessageType.SUCCESS, false);
+                    });
+                }
+            } else {
+                event.reply("❌ Code invalide ou expiré. Génère un nouveau code avec /link en jeu.")
+                        .setEphemeral(true)
+                        .queue();
+            }
+        });
+    }
+
+    /**
+     * Sends a private message to a Discord user
+     * @param discordId The Discord user ID to message
+     * @param message The message content to send
+     */
+    public void sendMessageToUser(String discordId, String message) {
+        if (jda == null) return;
+
+        jda.retrieveUserById(discordId).queue(user -> {
+            user.openPrivateChannel().queue(channel -> {
+                channel.sendMessage(message).queue();
+            });
+        }, error -> {
+            plugin.getLogger().log(Level.WARNING, "Impossible d'envoyer un message à l'utilisateur Discord: " + discordId);
+        });
+    }
+
+    /**
+     * Sends a message to a Discord text channel
+     * @param channelId The ID of the channel to message
+     * @param message The message content to send
+     */
+    public void sendMessageToChannel(String channelId, String message) {
+        if (jda == null) return;
+
+        jda.getTextChannelById(channelId).sendMessage(message).queue(null, error -> {
+            plugin.getLogger().log(Level.WARNING, "Impossible d'envoyer un message au canal Discord: " + channelId);
+        });
+    }
+}

--- a/src/main/java/fr/openmc/core/features/discordlink/DiscordLinkManager.java
+++ b/src/main/java/fr/openmc/core/features/discordlink/DiscordLinkManager.java
@@ -1,0 +1,186 @@
+package fr.openmc.core.features.discordlink;
+
+import fr.openmc.core.utils.database.DatabaseManager;
+
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import lombok.Getter;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import fr.openmc.core.OMCPlugin;
+
+public class DiscordLinkManager {
+    @Getter
+    private static DiscordLinkManager instance;
+    private final OMCPlugin plugin;
+    @Getter
+    private final DiscordBot bot;
+    private static final String TABLE_NAME = "discord_links";
+
+    // Stocke les codes de vérification temporaires (code -> uuid du joueur)
+    private final Map<String, String> pendingLinks;
+
+
+    public DiscordLinkManager(OMCPlugin plugin) {
+        this.plugin = plugin;
+        String token = plugin.getConfig().getString("bot-discord.bot-token");
+        if (token != null && !token.isEmpty()) {
+            this.bot = new DiscordBot(plugin);
+            this.bot.startBot();
+        } else {
+            this.bot = null;
+            plugin.getLogger().warning("Le token du bot Discord n'est pas configuré!");
+        }
+
+        instance = this;
+        this.pendingLinks = new HashMap<>();
+        initDatabase();
+    }
+
+    /**
+     * Initializes the database table for storing Discord-Minecraft account links
+     * Creates the table if it doesn't exist with columns for Minecraft UUID, Discord ID, and link date
+     */
+    private void initDatabase() {
+        try (Connection conn = DatabaseManager.getConnection()) {
+            conn.prepareStatement("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " (" +
+                    "minecraft_uuid VARCHAR(36) PRIMARY KEY," +
+                    "discord_id VARCHAR(20) NOT NULL UNIQUE," +
+                    "link_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP" +
+                    ")").executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Generates a verification code for linking Discord and Minecraft accounts
+     * @param player The Minecraft player to generate code for
+     * @return The 6-digit verification code as a string
+     */
+    public String generateVerificationCode(Player player) {
+        String code = String.format("%06d", new Random().nextInt(999999));
+        pendingLinks.put(code, player.getUniqueId().toString());
+
+        // Supprimer le code après 5 minutes
+        Bukkit.getScheduler().runTaskLater(OMCPlugin.getInstance(), () -> {
+            pendingLinks.remove(code);
+        }, 20 * 60 * 5);
+
+        return code;
+    }
+
+    /**
+     * Links a Minecraft account to a Discord account using a verification code
+     * @param code The verification code generated for the player
+     * @param discordId The Discord ID to link with the Minecraft account
+     * @return CompletableFuture that resolves to true if linking succeeded, false otherwise
+     */
+    public CompletableFuture<Boolean> linkAccounts(String code, String discordId) {
+        return CompletableFuture.supplyAsync(() -> {
+            if (!pendingLinks.containsKey(code)) {
+                return false;
+            }
+
+            String minecraftUUID = pendingLinks.get(code);
+
+            try (Connection conn = DatabaseManager.getConnection()) {
+                // Vérifier si le compte Discord est déjà lié
+                PreparedStatement checkStmt = conn.prepareStatement(
+                        "SELECT minecraft_uuid FROM " + TABLE_NAME + " WHERE discord_id = ?");
+                checkStmt.setString(1, discordId);
+                ResultSet rs = checkStmt.executeQuery();
+
+                if (rs.next()) {
+                    return false; // Compte Discord déjà lié
+                }
+
+                // Insérer la nouvelle liaison
+                PreparedStatement insertStmt = conn.prepareStatement(
+                        "INSERT INTO " + TABLE_NAME + " (minecraft_uuid, discord_id) VALUES (?, ?)");
+                insertStmt.setString(1, minecraftUUID);
+                insertStmt.setString(2, discordId);
+                insertStmt.executeUpdate();
+
+                pendingLinks.remove(code);
+                return true;
+            } catch (SQLException e) {
+                e.printStackTrace();
+                return false;
+            }
+        });
+    }
+
+    /**
+     * Retrieves the Discord ID associated with a Minecraft UUID
+     * @param minecraftUUID The Minecraft player's UUID
+     * @return CompletableFuture that resolves to the Discord ID or null if not linked
+     */
+    public CompletableFuture<String> getDiscordId(UUID minecraftUUID) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection conn = DatabaseManager.getConnection()) {
+                PreparedStatement stmt = conn.prepareStatement(
+                        "SELECT discord_id FROM " + TABLE_NAME + " WHERE minecraft_uuid = ?");
+                stmt.setString(1, minecraftUUID.toString());
+                ResultSet rs = stmt.executeQuery();
+
+                return rs.next() ? rs.getString("discord_id") : null;
+            } catch (SQLException e) {
+                e.printStackTrace();
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Retrieves the Minecraft UUID associated with a Discord ID
+     * @param discordId The Discord user's ID
+     * @return CompletableFuture that resolves to the Minecraft UUID or null if not linked
+     */
+    public CompletableFuture<String> getMinecraftUUID(String discordId) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection conn = DatabaseManager.getConnection()) {
+                PreparedStatement stmt = conn.prepareStatement(
+                        "SELECT minecraft_uuid FROM " + TABLE_NAME + " WHERE discord_id = ?");
+                stmt.setString(1, discordId);
+                ResultSet rs = stmt.executeQuery();
+
+                return rs.next() ? rs.getString("minecraft_uuid") : null;
+            } catch (SQLException e) {
+                e.printStackTrace();
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Checks if a Minecraft account is linked to any Discord account
+     * @param minecraftUUID The Minecraft player's UUID to check
+     * @return CompletableFuture that resolves to true if linked, false otherwise
+     */
+    public CompletableFuture<Boolean> isLinked(UUID minecraftUUID) {
+        return getDiscordId(minecraftUUID).thenApply(Objects::nonNull);
+    }
+
+    /**
+     * Unlinks a Minecraft account from its associated Discord account
+     * @param minecraftUUID The Minecraft player's UUID to unlink
+     * @return CompletableFuture that resolves to true if unlinking succeeded, false otherwise
+     */
+    public CompletableFuture<Boolean> unlinkAccount(UUID minecraftUUID) {
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection conn = DatabaseManager.getConnection()) {
+                PreparedStatement stmt = conn.prepareStatement(
+                        "DELETE FROM " + TABLE_NAME + " WHERE minecraft_uuid = ?");
+                stmt.setString(1, minecraftUUID.toString());
+                return stmt.executeUpdate() > 0;
+            } catch (SQLException e) {
+                e.printStackTrace();
+                return false;
+            }
+        });
+    }
+}

--- a/src/main/java/fr/openmc/core/features/discordlink/commands/DiscordLinkCommand.java
+++ b/src/main/java/fr/openmc/core/features/discordlink/commands/DiscordLinkCommand.java
@@ -1,0 +1,132 @@
+package fr.openmc.core.features.discordlink.commands;
+
+import fr.openmc.core.OMCPlugin;
+import fr.openmc.core.features.discordlink.DiscordLinkManager;
+import fr.openmc.core.utils.messages.MessageType;
+import fr.openmc.core.utils.messages.MessagesManager;
+import fr.openmc.core.utils.messages.Prefix;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.DefaultFor;
+import revxrsal.commands.annotation.Subcommand;
+import revxrsal.commands.bukkit.annotation.CommandPermission;
+
+import java.util.Objects;
+
+@Command({"discordlink", "link"})
+public class DiscordLinkCommand {
+
+    @DefaultFor("~")
+    void mainCommand(CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            MessagesManager.sendMessage(sender, Component.text("Cette commande est réservée aux joueurs."),
+                    Prefix.DISCORD, MessageType.ERROR, false);
+            return;
+        }
+
+        Player player = (Player) sender;
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                boolean isLinked = DiscordLinkManager.getInstance().isLinked(player.getUniqueId()).join();
+                if (isLinked) {
+                    MessagesManager.sendMessage(player,
+                            Component.text("Ton compte est déjà lié à Discord."),
+                            Prefix.DISCORD, MessageType.ERROR, false);
+                    return;
+                }
+
+                String code = DiscordLinkManager.getInstance().generateVerificationCode(player);
+
+                Component message = Component.text()
+                        .append(Component.text("Voici ton code de vérification: ", NamedTextColor.GRAY))
+                        .append(Component.text(code, NamedTextColor.YELLOW))
+                        .append(Component.newline())
+                        .append(Component.text("Utilise la commande ", NamedTextColor.GRAY))
+                        .append(Component.text("/link " + code, NamedTextColor.LIGHT_PURPLE))
+                        .append(Component.text(" sur Discord.", NamedTextColor.GRAY))
+                        .append(Component.newline())
+                        .append(Component.text("Ce code expirera dans ", NamedTextColor.GRAY))
+                        .append(Component.text("5 minutes", NamedTextColor.RED))
+                        .append(Component.text(".", NamedTextColor.GRAY))
+                        .build();
+
+                MessagesManager.sendMessage(player, message, Prefix.DISCORD, MessageType.SUCCESS, false);
+            }
+        }.runTaskAsynchronously(OMCPlugin.getInstance());
+    }
+
+    @Subcommand("status")
+    void checkLinkStatus(Player player) {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                String discordId = DiscordLinkManager.getInstance().getDiscordId(player.getUniqueId()).join();
+
+                if (discordId != null) {
+                    MessagesManager.sendMessage(player,
+                            Component.text("Ton compte Minecraft est lié à Discord (ID: ")
+                                    .append(Component.text(discordId, NamedTextColor.GREEN)),
+                            Prefix.DISCORD, MessageType.SUCCESS, false);
+                } else {
+                    MessagesManager.sendMessage(player,
+                            Component.text("Ton compte Minecraft n'est pas lié à Discord. Utilise ")
+                                    .append(Component.text("/link", NamedTextColor.LIGHT_PURPLE))
+                                    .append(Component.text(" pour commencer.", NamedTextColor.GRAY)),
+                            Prefix.DISCORD, MessageType.INFO, false);
+                }
+            }
+        }.runTaskAsynchronously(OMCPlugin.getInstance());
+    }
+
+    @Subcommand("unlink")
+    void unlinkAccount(Player player) {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                boolean success = DiscordLinkManager.getInstance().unlinkAccount(player.getUniqueId()).join();
+
+                if (success) {
+                    MessagesManager.sendMessage(player,
+                            Component.text("Ton compte a été dissocié avec succès."),
+                            Prefix.DISCORD, MessageType.SUCCESS, false);
+                } else {
+                    MessagesManager.sendMessage(player,
+                            Component.text("Ton compte n'est pas lié à Discord."),
+                            Prefix.DISCORD, MessageType.ERROR, false);
+                }
+            }
+        }.runTaskAsynchronously(OMCPlugin.getInstance());
+    }
+
+    // Commande admin pour vérifier les liaisons
+    @Subcommand("check")
+    @CommandPermission("omc.admin.commands.discordlink.check")
+    void adminCheckCommand(CommandSender sender, Player target) {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                String discordId = DiscordLinkManager.getInstance().getDiscordId(target.getUniqueId()).join();
+
+                if (discordId != null) {
+                    MessagesManager.sendMessage(sender,
+                            Component.text("Le joueur ")
+                                    .append(Component.text(target.getName(), NamedTextColor.YELLOW))
+                                    .append(Component.text(" est lié à Discord (ID: "))
+                                    .append(Component.text(discordId, NamedTextColor.GREEN)),
+                            Prefix.DISCORD, MessageType.SUCCESS, false);
+                } else {
+                    MessagesManager.sendMessage(sender,
+                            Component.text("Le joueur ")
+                                    .append(Component.text(target.getName(), NamedTextColor.YELLOW))
+                                    .append(Component.text(" n'est pas lié à Discord.")),
+                            Prefix.DISCORD, MessageType.INFO, false);
+                }
+            }
+        }.runTaskAsynchronously(OMCPlugin.getInstance());
+    }
+}

--- a/src/main/java/fr/openmc/core/utils/messages/Prefix.java
+++ b/src/main/java/fr/openmc/core/utils/messages/Prefix.java
@@ -26,7 +26,8 @@ public enum Prefix {
     SHOP("<gradient:#084CFB:#5AAFC4>ѕʜᴏᴘ</gradient>"),
     ADMINSHOP("<gradient:#EE2222:#F04949>ᴀᴅᴍɪɴꜱʜᴏᴘ</gradient>"),
     ACCOUTDETECTION("<gradient:#F45454:#545eb6>ᴀᴄᴄᴏᴜɴᴛ ᴅᴇᴛᴇᴄᴛɪᴏɴ</gradient>"),
-    DEATH("<gradient:#FF0000:#FF7F7F>☠</gradient>")
+    DEATH("<gradient:#FF0000:#FF7F7F>☠</gradient>"),
+    DISCORD("<gradient:#7289DA:#99AAB5>ᴅɪѕᴄᴏʀᴅ</gradient>"),
     ;
 
     @Getter private final String prefix;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,10 @@ chat:
   # {prefix}, {suffix}, {name}, {message}
   message: "&r{prefix} {name}&8: &f{message}"
 
+bot-discord:
+  bot-token: "TOKEN_BOT_DISCORD"
+  guild-id: "ID_SERVEUR_DISCORD"
+
 #####
 # Paramètres pour un environnement de production
 #####


### PR DESCRIPTION
Ajoute la possibilité aux joueurs,
de lier leur compte discord à minecraft

## Petit résumé de la PR:


## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [] Fournir un profileur (si besoin/demandé par un admin)
- [] Avoir une milestone associée à la PR
- [x] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
* #455 

## Decrivez vos changements

![image](https://github.com/user-attachments/assets/66a2dd9f-f076-4f8b-a68a-d07f22b580f3)
![image](https://github.com/user-attachments/assets/44758410-3a5f-47ce-b2a9-920d169960cf)
![image](https://github.com/user-attachments/assets/fc0c1e8d-f8c8-48be-8bd1-7af302ec58f4)
![image](https://github.com/user-attachments/assets/521f7047-e9ea-42d7-9561-e2f9d2d3e81b)

