### PR TITLE
Pouvoir modifier son home par le menu de panneau

### DIFF
--- a/src/main/java/fr/openmc/api/input/signgui/wrapper/MojangWrapper.java
+++ b/src/main/java/fr/openmc/api/input/signgui/wrapper/MojangWrapper.java
@@ -44,7 +44,7 @@ public class MojangWrapper {
     public List<Material> getSignTypes() {
         return Arrays.asList(Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN, Material.JUNGLE_SIGN,
                 Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.CRIMSON_SIGN, Material.WARPED_SIGN,
-                Material.CHERRY_SIGN, Material.MANGROVE_SIGN, Material.BAMBOO_SIGN
+                Material.CHERRY_SIGN, Material.MANGROVE_SIGN, Material.BAMBOO_SIGN, Material.PALE_OAK_SIGN
         );
     }
 

--- a/src/main/java/fr/openmc/core/features/homes/command/RelocateHome.java
+++ b/src/main/java/fr/openmc/core/features/homes/command/RelocateHome.java
@@ -20,8 +20,6 @@ import revxrsal.commands.bukkit.annotation.CommandPermission;
 import java.util.List;
 
 public class RelocateHome {
-
-    private MessagesManager msg;
     private final HomesManager homeManager;
 
     public RelocateHome(HomesManager homeManager) {
@@ -54,7 +52,7 @@ public class RelocateHome {
                 return;
             }
 
-            if (HomeUtil.checkName(player, msg, homeName)) return;
+            if (HomeUtil.checkName(player, homeName)) return;
 
             List<Home> homes = HomesManager.getHomes(target.getUniqueId());
             for (Home h : homes) {

--- a/src/main/java/fr/openmc/core/features/homes/command/RenameHome.java
+++ b/src/main/java/fr/openmc/core/features/homes/command/RenameHome.java
@@ -18,8 +18,6 @@ import revxrsal.commands.bukkit.annotation.CommandPermission;
 import java.util.List;
 
 public class RenameHome {
-
-    private MessagesManager msg;
     private final HomesManager homesManager;
     public RenameHome(HomesManager homesManager) {
         this.homesManager = homesManager;
@@ -43,7 +41,7 @@ public class RenameHome {
                 return;
             }
 
-            if (HomeUtil.checkName(player, msg, newName)) return;
+            if (HomeUtil.checkName(player, newName)) return;
 
             List<Home> homes = HomesManager.getHomes(target.getUniqueId());
             for (Home h : homes) {
@@ -64,7 +62,7 @@ public class RenameHome {
             return;
         }
 
-        if(HomeUtil.checkName(player, msg, newName)) return;
+        if(HomeUtil.checkName(player, newName)) return;
 
         List<Home> homes = HomesManager.getHomes(player.getUniqueId());
 

--- a/src/main/java/fr/openmc/core/features/homes/command/SetHome.java
+++ b/src/main/java/fr/openmc/core/features/homes/command/SetHome.java
@@ -18,8 +18,6 @@ import revxrsal.commands.bukkit.annotation.CommandPermission;
 import java.util.List;
 
 public class SetHome {
-
-    private MessagesManager msg;
     private final HomesManager homesManager;
 
     public SetHome(HomesManager homesManager) {
@@ -53,7 +51,7 @@ public class SetHome {
                 return;
             }
 
-            if(HomeUtil.checkName(player, msg, homeName)) return;
+            if(HomeUtil.checkName(player, homeName)) return;
 
             List<Home> homes = HomesManager.getHomes(target.getUniqueId());
             for (Home home : homes) {
@@ -74,7 +72,7 @@ public class SetHome {
             return;
         }
 
-        if(HomeUtil.checkName(player, msg, name)) return;
+        if(HomeUtil.checkName(player, name)) return;
 
         int currentHome = HomesManager.getHomes(player.getUniqueId()).size();
         int homesLimit = homesManager.getHomeLimit(player.getUniqueId());

--- a/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
+++ b/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
@@ -19,6 +19,8 @@ import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -65,13 +67,14 @@ public class HomeConfigMenu extends Menu {
             }).setNextMenu(new HomeChangeIconMenu(player, home)));
 
             content.put(22, new ItemBuilder(this, Material.NAME_TAG, itemMeta -> {
-                itemMeta.displayName(Component.text("Changer le nom", NamedTextColor.GREEN));
+                itemMeta.displayName(Component.text("Changer le nom", NamedTextColor.GREEN).style(Style.style(TextDecoration.ITALIC.withState(false))));
 
                 TextComponent lore = Component.text()
                         .append(Component.text("■ ", NamedTextColor.GRAY))
                         .append(Component.text("Clique ", NamedTextColor.GREEN))
                         .append(Component.text("gauche ", NamedTextColor.DARK_GREEN))
                         .append(Component.text("pour changer le nom de votre home", NamedTextColor.GREEN))
+                        .style(Style.style(TextDecoration.ITALIC.withState(false)))
                         .build();
                 itemMeta.lore(Collections.singletonList(lore));
             }).setOnClick(e -> {

--- a/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
+++ b/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
@@ -1,25 +1,33 @@
 package fr.openmc.core.features.homes.menu;
 
+import fr.openmc.api.input.signgui.SignGUI;
+import fr.openmc.api.input.signgui.exception.SignGUIVersionException;
 import fr.openmc.api.menulib.Menu;
 import fr.openmc.api.menulib.utils.InventorySize;
 import fr.openmc.api.menulib.utils.ItemBuilder;
 import fr.openmc.core.features.homes.Home;
+import fr.openmc.core.features.homes.HomesManager;
 import fr.openmc.core.features.homes.utils.HomeUtil;
 import fr.openmc.core.features.mailboxes.utils.MailboxMenuManager;
+import fr.openmc.core.utils.ItemUtils;
+import fr.openmc.core.utils.customfonts.CustomFonts;
+import fr.openmc.core.utils.customitems.CustomItemRegistry;
 import fr.openmc.core.utils.messages.MessageType;
 import fr.openmc.core.utils.messages.MessagesManager;
 import fr.openmc.core.utils.messages.Prefix;
-import fr.openmc.core.utils.customitems.CustomItemRegistry;
-import fr.openmc.core.utils.customfonts.CustomFonts;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,15 +59,71 @@ public class HomeConfigMenu extends Menu {
         try {
             content.put(4, home.getIconItem());
 
-            content.put(20, new ItemBuilder(this, HomeUtil.getRandomsIcons(),itemMeta -> {
+            content.put(20, new ItemBuilder(this, HomeUtil.getRandomsIcons(), itemMeta -> {
                 itemMeta.setDisplayName("§aChanger l'icône");
                 itemMeta.setLore(List.of(ChatColor.GRAY + "■ §aClique §2gauche §apour changer l'icône de votre home"));
             }).setNextMenu(new HomeChangeIconMenu(player, home)));
 
-        content.put(24, new ItemBuilder(this, CustomItemRegistry.getByName("omc_homes:omc_homes_icon_bin_red").getBest(), itemMeta -> {
-            itemMeta.setDisplayName(CustomFonts.getBest("omc_homes:bin", "§c🗑") + " §cSupprimer le home");
-            itemMeta.setLore(List.of(ChatColor.GRAY + "■ §cClique §4gauche §cpour supprimer votre home"));
-        }).setNextMenu(new HomeDeleteConfirmMenu(getOwner(), home)));
+            content.put(22, new ItemBuilder(this, Material.NAME_TAG, itemMeta -> {
+                itemMeta.displayName(Component.text("Changer le nom", NamedTextColor.GREEN));
+
+                TextComponent lore = Component.text()
+                        .append(Component.text("■ ", NamedTextColor.GRAY))
+                        .append(Component.text("Clique ", NamedTextColor.GREEN))
+                        .append(Component.text("gauche ", NamedTextColor.DARK_GREEN))
+                        .append(Component.text("pour changer le nom de votre home", NamedTextColor.GREEN))
+                        .build();
+                itemMeta.lore(Collections.singletonList(lore));
+            }).setOnClick(e -> {
+                String[] lines = {
+                        "",
+                        " ᐱᐱᐱᐱᐱᐱᐱ ",
+                        "Entrez votre",
+                        "nom ci dessus"
+                };
+
+                SignGUI gui;
+                try {
+                    gui = SignGUI.builder()
+                            .setLines(lines)
+                            .setType(ItemUtils.getSignType(player))
+                            .setHandler((p, result) -> {
+                                String input = result.getLine(0);
+
+                                if (!HomeUtil.checkName(player, input))
+                                    return Collections.emptyList();
+
+                                if (HomesManager.getHomesNames(p.getUniqueId()).contains(input)) {
+                                    TextComponent message = Component.text("Tu as déjà un home avec ce nom.", NamedTextColor.RED);
+                                    MessagesManager.sendMessage(player, message, Prefix.HOME, MessageType.ERROR, true);
+                                    return Collections.emptyList();
+                                }
+
+                                TextComponent message = Component.text()
+                                        .append(Component.text("Ton home ", NamedTextColor.GREEN))
+                                        .append(Component.text(home.getName(), NamedTextColor.YELLOW))
+                                        .append(Component.text(" a été renommé en ", NamedTextColor.GREEN))
+                                        .append(Component.text(input, NamedTextColor.YELLOW))
+                                        .append(Component.text(".", NamedTextColor.GREEN))
+                                        .build();
+
+                                MessagesManager.sendMessage(player, message, Prefix.HOME, MessageType.SUCCESS, true);
+                                HomesManager.getInstance().renameHome(home, input);
+
+                                return Collections.emptyList();
+                            })
+                            .build();
+                } catch (SignGUIVersionException ex) {
+                    throw new RuntimeException(ex);
+                }
+
+                gui.open(player);
+            }));
+
+            content.put(24, new ItemBuilder(this, CustomItemRegistry.getByName("omc_homes:omc_homes_icon_bin_red").getBest(), itemMeta -> {
+                itemMeta.setDisplayName(CustomFonts.getBest("omc_homes:bin", "§c🗑") + " §cSupprimer le home");
+                itemMeta.setLore(List.of(ChatColor.GRAY + "■ §cClique §4gauche §cpour supprimer votre home"));
+            }).setNextMenu(new HomeDeleteConfirmMenu(getOwner(), home)));
 
             content.put(36, new ItemBuilder(this, MailboxMenuManager.previousPageBtn()).setNextMenu(new HomeMenu(player)));
             content.put(44, new ItemBuilder(this, MailboxMenuManager.cancelBtn()).setCloseButton());
@@ -74,7 +138,8 @@ public class HomeConfigMenu extends Menu {
     }
 
     @Override
-    public void onInventoryClick(InventoryClickEvent inventoryClickEvent) {}
+    public void onInventoryClick(InventoryClickEvent inventoryClickEvent) {
+    }
 
     @Override
     public void onClose(InventoryCloseEvent event) {

--- a/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
+++ b/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
@@ -91,7 +91,6 @@ public class HomeConfigMenu extends Menu {
                             .setLines(lines)
                             .setType(ItemUtils.getSignType(player))
                             .setHandler((p, result) -> {
-                                System.out.println("aaaaa");
                                 String input = result.getLine(0);
 
                                 if (HomeUtil.checkName(player, input))

--- a/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
+++ b/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
@@ -91,9 +91,10 @@ public class HomeConfigMenu extends Menu {
                             .setLines(lines)
                             .setType(ItemUtils.getSignType(player))
                             .setHandler((p, result) -> {
+                                System.out.println("aaaaa");
                                 String input = result.getLine(0);
 
-                                if (!HomeUtil.checkName(player, input))
+                                if (HomeUtil.checkName(player, input))
                                     return Collections.emptyList();
 
                                 if (HomesManager.getHomesNames(p.getUniqueId()).contains(input)) {

--- a/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
+++ b/src/main/java/fr/openmc/core/features/homes/menu/HomeConfigMenu.java
@@ -67,7 +67,7 @@ public class HomeConfigMenu extends Menu {
             }).setNextMenu(new HomeChangeIconMenu(player, home)));
 
             content.put(22, new ItemBuilder(this, Material.NAME_TAG, itemMeta -> {
-                itemMeta.displayName(Component.text("Changer le nom", NamedTextColor.GREEN).style(Style.style(TextDecoration.ITALIC.withState(false))));
+                itemMeta.displayName(Component.text("Changer le nom", NamedTextColor.GREEN).decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE));
 
                 TextComponent lore = Component.text()
                         .append(Component.text("■ ", NamedTextColor.GRAY))

--- a/src/main/java/fr/openmc/core/features/homes/utils/HomeUtil.java
+++ b/src/main/java/fr/openmc/core/features/homes/utils/HomeUtil.java
@@ -1,6 +1,5 @@
 package fr.openmc.core.features.homes.utils;
 
-import dev.lone.itemsadder.api.CustomStack;
 import fr.openmc.core.OMCPlugin;
 import fr.openmc.core.features.homes.Home;
 import fr.openmc.core.features.homes.HomeIcons;
@@ -74,7 +73,7 @@ public class HomeUtil {
         return CustomItemRegistry.getByName(iconKey).getBest();
     }
 
-    public static boolean checkName(Player player, MessagesManager msg, String name) {
+    public static boolean checkName(Player player, String name) {
         if(WorldGuardApi.isRegionConflict(player.getLocation())) {
             MessagesManager.sendMessage(player, Component.text("§cVous ne pouvez pas ajouter un home dans une région protégée !"), Prefix.HOME, MessageType.ERROR, true);
             return true;


### PR DESCRIPTION
## Petit résumé de la PR:
On peut maintenant renommer les homes directement depuis le menu de configuration des homes

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [x] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#381 

## Decrivez vos changements
J'ai juste ajoutée la fonction de SignGUI au menu (j'ai mis un nametag vu que je savais pas quoi mettre d'autre)
