### PR TITLE
Fix un bug quand on essaye d'afficher la deuxième page des quêtes

### DIFF
--- a/src/main/java/fr/openmc/core/features/quests/command/QuestCommand.java
+++ b/src/main/java/fr/openmc/core/features/quests/command/QuestCommand.java
@@ -7,7 +7,7 @@ import fr.openmc.core.utils.messages.Prefix;
 import org.bukkit.entity.Player;
 import revxrsal.commands.annotation.*;
 
-@Command({"quest"})
+@Command({"quest", "quests"})
 @Description("Commande pour les quêtes")
 public class QuestCommand {
 

--- a/src/main/java/fr/openmc/core/features/quests/menus/QuestsMenu.java
+++ b/src/main/java/fr/openmc/core/features/quests/menus/QuestsMenu.java
@@ -208,7 +208,7 @@ public class QuestsMenu extends Menu {
                         if (reward instanceof QuestItemReward itemReward) {
                             ItemStack rewardItem = itemReward.getItemStack();
                             String itemName = PlainTextComponentSerializer.plainText().serialize(rewardItem.displayName());
-                            lore.add(Component.text("    §7- §f" + itemName + " §7x" + rewardItem.getAmount()));
+                            lore.add(Component.text("    §7- §f" + itemName + " §7x" + itemReward.getAmount()));
                         } else if (reward instanceof QuestMoneyReward moneyReward) {
                             lore.add(Component.text("    §7- §6" + EconomyManager.getFormattedSimplifiedNumber(moneyReward.getAmount()) + " §f" + EconomyManager.getEconomyIcon()));
                         }
@@ -223,7 +223,7 @@ public class QuestsMenu extends Menu {
                 if (reward instanceof QuestItemReward itemReward) {
                     ItemStack rewardItem = itemReward.getItemStack();
                     String itemName = PlainTextComponentSerializer.plainText().serialize(rewardItem.displayName());
-                    lore.add(Component.text("  §7- §f" + itemName + " §7x" + rewardItem.getAmount()));
+                    lore.add(Component.text("  §7- §f" + itemName + " §7x" + itemReward.getAmount()));
                 } else if (reward instanceof QuestMoneyReward moneyReward) {
                     lore.add(Component.text("  §7- §6" + EconomyManager.getFormattedSimplifiedNumber(moneyReward.getAmount()) + " §f" + EconomyManager.getEconomyIcon()));
                 }

--- a/src/main/java/fr/openmc/core/features/quests/rewards/QuestItemReward.java
+++ b/src/main/java/fr/openmc/core/features/quests/rewards/QuestItemReward.java
@@ -9,6 +9,7 @@ import org.bukkit.inventory.ItemStack;
 @Getter
 public class QuestItemReward implements QuestReward {
     private final ItemStack itemStack;
+    private final int amount;
 
     /**
      * Create a new QuestItemReward.
@@ -17,7 +18,8 @@ public class QuestItemReward implements QuestReward {
      * @param amount   The amount of the item.
      */
     public QuestItemReward(Material material, int amount) {
-        this.itemStack = new ItemStack(material, amount);
+        this.itemStack = new ItemStack(material);
+        this.amount = amount;
     }
 
     /**
@@ -28,7 +30,7 @@ public class QuestItemReward implements QuestReward {
      */
     public QuestItemReward(ItemStack material, int amount) {
         this.itemStack = material;
-        this.itemStack.setAmount(amount);
+        this.amount = amount;
     }
 
     /**
@@ -39,11 +41,20 @@ public class QuestItemReward implements QuestReward {
      */
     @Override
     public void giveReward(Player player) {
-        ItemStack item = itemStack.clone();
-        if (AdminShopManager.hasEnoughSpace(player, item)) {
-            player.getInventory().addItem(item);
-        } else {
-            player.getWorld().dropItem(player.getLocation(), item);
+        int remaining = amount;
+        while (remaining > 0) {
+            int stackAmount = Math.min(remaining, itemStack.getMaxStackSize());
+
+            ItemStack item = itemStack.clone();
+            item.setAmount(stackAmount);
+
+            if (AdminShopManager.hasEnoughSpace(player, item)) {
+                player.getInventory().addItem(item);
+            } else {
+                player.getWorld().dropItem(player.getLocation(), item);
+            }
+
+            remaining -= stackAmount;
         }
     }
 }

--- a/src/main/java/fr/openmc/core/features/quests/rewards/QuestItemReward.java
+++ b/src/main/java/fr/openmc/core/features/quests/rewards/QuestItemReward.java
@@ -34,10 +34,13 @@ public class QuestItemReward implements QuestReward {
     }
 
     /**
-     * Give the reward to the player.
+     * Gives the reward to the specified player.
      * <p>
-     * If  the player's inventory is full, the item will be dropped on the ground.
-     * @param player The player to give the reward to.
+     * The reward is split into stacks no larger than the item's maximum stack size.
+     * If the player's inventory has enough space, each stack is added to the inventory.
+     * Otherwise, any stack that cannot be fully accommodated is dropped at the player's location.
+     *
+     * @param player the target player for the reward.
      */
     @Override
     public void giveReward(Player player) {


### PR DESCRIPTION
## Petit résumé de la PR:
Les récompenses sont désormais divisées en stacks ne dépassant pas la taille maximale de stack de l'item.
Si l'inventaire du joueur est plein, les items restants sont droppés au sol à la position du joueur.

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#471 

## Decrivez vos changements
A la ligne 225 de QuestsMenu.java
`String itemName = PlainTextComponentSerializer.plainText().serialize(rewardItem.displayName());`
Il "décodait" l'item ce qui faisait qu'il vérifiait le nombre d'items dans un seul ItemStack sauf que ça ne peut pas dépasser 99 dans minecraft.
Donc maintenant plutôt que de le mettre dans l'ItemStack il le stock à part et l'utilise seulement pour donner la récompense au joueur. (Sauvez moi je suis nulle en écriture)
