### PR TITLE
[FIX] Ajoute la "sauvegarde" de l'état de la bossbar pour un joueur

### DIFF
--- a/src/main/java/fr/openmc/core/features/bossbar/BossbarManager.java
+++ b/src/main/java/fr/openmc/core/features/bossbar/BossbarManager.java
@@ -22,6 +22,7 @@ public class BossbarManager {
     @Getter
     private static BossbarManager instance;
     private final Map<UUID, BossBar> activeBossBars = new HashMap<>();
+    private final Map<UUID, Boolean> playerPreferences = new HashMap<>();
     @Getter
     private final List<Component> helpMessages = new ArrayList<>();
     @Getter
@@ -104,6 +105,10 @@ public class BossbarManager {
     public void addBossBar(Player player) {
         if (!bossBarEnabled || activeBossBars.containsKey(player.getUniqueId())) return;
 
+        Boolean preference = playerPreferences.get(player.getUniqueId());
+        if (preference != null && !preference) {
+            return;
+        }
         removeBossBar(player);
 
         BossBar bossBar = BossBar.bossBar(
@@ -133,11 +138,15 @@ public class BossbarManager {
      * @param player The player to toggle the bossbar for
      */
     public void toggleBossBar(Player player) {
+        UUID uuid = player.getUniqueId();
+
         if (activeBossBars.containsKey(player.getUniqueId())) {
             removeBossBar(player);
+            playerPreferences.put(uuid, false);
             MessagesManager.sendMessage(player, Component.text("Bossbar désactivée"), Prefix.OPENMC, MessageType.WARNING, true);
         } else {
             addBossBar(player);
+            playerPreferences.put(uuid, true);
             MessagesManager.sendMessage(player, Component.text("Bossbar activée"), Prefix.OPENMC, MessageType.SUCCESS, true);
         }
     }


### PR DESCRIPTION
Ajoute la sauvegarde d'état,
de la bossbar pour éviter de
faire /bb pour la désactiver.

## Petit résumé de la PR:


## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [x] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
* #470 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->
