### PR TITLE
Ajout d'argent à la première connexion d'un joueur

### DIFF
--- a/src/main/java/fr/openmc/core/listeners/JoinMessageListener.java
+++ b/src/main/java/fr/openmc/core/listeners/JoinMessageListener.java
@@ -47,19 +47,19 @@ public class JoinMessageListener implements Listener {
         // Quest pending reward notification
         Bukkit.getScheduler().runTaskAsynchronously(OMCPlugin.getInstance(), () -> {
             for (Quest quest : QuestsManager.getAllQuests()) {
-                if (quest.hasPendingRewards(player.getUniqueId())) {
-                    int pendingRewardsNumber = quest.getPendingRewardTiers(player.getUniqueId()).size();
-                    Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> {
-                        MessagesManager.sendMessage(player,
-                                Component.text("§aVous avez " + pendingRewardsNumber + " récompense(s) de quête en attente.")
-                                        .append(Component.text(" §6Cliquez ici pour les récupérer."))
-                                                .clickEvent(ClickEvent.runCommand("/quest")),
-                                Prefix.QUEST,
-                                MessageType.INFO,
-                                true);
-                    });
-                    break;
-                }
+                if (!quest.hasPendingRewards(player.getUniqueId()))
+                    continue;
+
+                int pendingRewardsNumber = quest.getPendingRewardTiers(player.getUniqueId()).size();
+                Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> {
+                    MessagesManager.sendMessage(player,
+                            Component.text("§aVous avez " + pendingRewardsNumber + " récompense(s) de quête en attente.")
+                                    .append(Component.text(" §6Cliquez ici pour les récupérer."))
+                                            .clickEvent(ClickEvent.runCommand("/quest")),
+                            Prefix.QUEST,
+                            MessageType.INFO,
+                            true);
+                });
             }
         });
 

--- a/src/main/java/fr/openmc/core/listeners/JoinMessageListener.java
+++ b/src/main/java/fr/openmc/core/listeners/JoinMessageListener.java
@@ -24,6 +24,11 @@ import org.bukkit.scheduler.BukkitRunnable;
 import java.util.UUID;
 
 public class JoinMessageListener implements Listener {
+    private final double balanceOnJoin;
+
+    public JoinMessageListener() {
+        this.balanceOnJoin = OMCPlugin.getInstance().getConfig().getDouble("money-on-first-join", 500D);
+    }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
@@ -69,7 +74,7 @@ public class JoinMessageListener implements Listener {
         // Adjust player's spawn location
         if (!player.hasPlayedBefore()) {
             player.teleport(SpawnManager.getSpawnLocation());
-            EconomyManager.setBalance(player.getUniqueId(), 500D);
+            EconomyManager.setBalance(player.getUniqueId(), this.balanceOnJoin);
         }
 
         new BukkitRunnable() {

--- a/src/main/java/fr/openmc/core/listeners/JoinMessageListener.java
+++ b/src/main/java/fr/openmc/core/listeners/JoinMessageListener.java
@@ -71,6 +71,11 @@ public class JoinMessageListener implements Listener {
         new BukkitRunnable() {
             @Override
             public void run() {
+                if (!player.isOnline()) {
+                    cancel();
+                    return;
+                }
+
                 TabList.updateTabList(player);
             }
         }.runTaskTimer(OMCPlugin.getInstance(), 0L, 100L);

--- a/src/main/java/fr/openmc/core/listeners/JoinMessageListener.java
+++ b/src/main/java/fr/openmc/core/listeners/JoinMessageListener.java
@@ -2,6 +2,7 @@ package fr.openmc.core.listeners;
 
 import fr.openmc.core.OMCPlugin;
 import fr.openmc.core.commands.utils.SpawnManager;
+import fr.openmc.core.features.economy.EconomyManager;
 import fr.openmc.core.features.friend.FriendManager;
 import fr.openmc.core.features.quests.QuestsManager;
 import fr.openmc.core.features.quests.objects.Quest;
@@ -66,7 +67,10 @@ public class JoinMessageListener implements Listener {
         event.joinMessage(Component.text("§8[§a§l+§8] §r" + "§r" + LuckPermsApi.getFormattedPAPIPrefix(player) + player.getName()));
 
         // Adjust player's spawn location
-        if (!player.hasPlayedBefore()) player.teleport(SpawnManager.getSpawnLocation());
+        if (!player.hasPlayedBefore()) {
+            player.teleport(SpawnManager.getSpawnLocation());
+            EconomyManager.setBalance(player.getUniqueId(), 500D);
+        }
 
         new BukkitRunnable() {
             @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,9 @@ chat:
   # {prefix}, {suffix}, {name}, {message}
   message: "&r{prefix} {name}&8: &f{message}"
 
+# Montant d'argent donné à un joueur lors de sa première connexion
+money-on-first-join: 500
+
 #####
 # Paramètres pour un environnement de production
 #####


### PR DESCRIPTION
## Petit résumé de la PR:
Ca donne maintenant de l'argent aux joueurs lorsqu'ils se connectent au serveur pour la première fois

## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#511 

## Decrivez vos changements
J'ai juste ajoutée un setBalance quand le joueur se connecte pour la première fois
Et l'ai ajoutée dans la config
