### PR TITLE
Fix quête aywenite quand ItemsAdder n'est pas sur le serveur

### DIFF
--- a/src/main/java/fr/openmc/core/features/quests/quests/MineAyweniteQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/MineAyweniteQuest.java
@@ -5,6 +5,7 @@ import fr.openmc.core.features.quests.objects.Quest;
 import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestItemReward;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
+import fr.openmc.core.utils.api.ItemsAdderApi;
 import fr.openmc.core.utils.customitems.CustomItemRegistry;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -32,6 +33,9 @@ public class MineAyweniteQuest extends Quest implements Listener {
         if (tool.containsEnchantment(Enchantment.SILK_TOUCH)) {
             return; // Ne pas compter si le joueur utilise Silk Touch
         }
+
+        if (!ItemsAdderApi.hasItemAdder())
+            return;
 
         CustomBlock customBlock = CustomBlock.byAlreadyPlaced(event.getBlock());
         if (customBlock != null && customBlock.getNamespacedID() != null &&


### PR DESCRIPTION
## Petit résumé de la PR:
Fix quête aywenite quand ItemsAdder n'est pas sur le serveur

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#393 

## Decrivez vos changements
Ajout d'un check si ItemsAdder est présent avant d'utiliser les class d'ItemsAdder
