### PR TITLE
Fix le nom des blocs dans le shop

### DIFF
--- a/src/main/java/fr/openmc/core/features/corporation/menu/shop/ShopMenu.java
+++ b/src/main/java/fr/openmc/core/features/corporation/menu/shop/ShopMenu.java
@@ -190,7 +190,7 @@ public class ShopMenu extends Menu {
         if (getCurrentItem() != null)
 
             content.put(itemSlot, new ItemBuilder(this, getCurrentItem().getItem(), itemMeta -> {
-                itemMeta.displayName(ItemUtils.getItemTranslation(getCurrentItem().getItem()).color(NamedTextColor.GRAY).decorate(TextDecoration.BOLD));
+                itemMeta.displayName(ItemUtils.getItemTranslation(getCurrentItem().getItem()).color(NamedTextColor.GRAY).decorate(TextDecoration.BOLD).decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE));
                 List<String> lore = new ArrayList<>();
                 lore.add("§7■ Prix: §c" + EconomyManager.getFormattedNumber(getCurrentItem().getPricePerItem() * amountToBuy));
                 lore.add("§7■ En stock: " + EconomyManager.getFormattedSimplifiedNumber(getCurrentItem().getAmount()));

--- a/src/main/java/fr/openmc/core/features/corporation/menu/shop/ShopMenu.java
+++ b/src/main/java/fr/openmc/core/features/corporation/menu/shop/ShopMenu.java
@@ -114,20 +114,7 @@ public class ShopMenu extends Menu {
         if (shop.getOwner().isCompany()){
             company = shop.getOwner().getCompany();
         }
-        if (company == null && shop.isOwner(getOwner().getUniqueId())) {
-            previousItemSlot = 39;
-            nextItemSlot = 41;
-            closeMenuSlot = 40;
-            purpleSetOne = 19;
-            redRemoveTen = 20;
-            redRemoveOne = 21;
-            itemSlot = 22;
-            greenAddOne = 23;
-            greenAddTen = 24;
-            purpleAddSixtyFour = 25;
-            catalogue = 44;
-            ownerItem = true;
-        } else if (company != null && company.getAllMembers().contains(getOwner().getUniqueId())) {
+        if ((company == null && shop.isOwner(getOwner().getUniqueId())) || (company != null && company.getAllMembers().contains(getOwner().getUniqueId()))) {
             previousItemSlot = 39;
             nextItemSlot = 41;
             closeMenuSlot = 40;

--- a/src/main/java/fr/openmc/core/utils/ItemUtils.java
+++ b/src/main/java/fr/openmc/core/utils/ItemUtils.java
@@ -25,7 +25,7 @@ public class ItemUtils {
      */
     public static TranslatableComponent getItemTranslation(ItemStack stack) {
         return Component.translatable(Objects.requireNonNullElse(
-                stack.getType().getItemTranslationKey(),
+                stack.getType().translationKey(),
                 "block.minecraft.stone"
         ));
     }


### PR DESCRIPTION
## Petit résumé de la PR:
Fix le nom des blocs dans le shop:
`TranslatableComponentImpl{key="block.minecraft.redstone_block", arguments=[], fallback=null, style=StyleImpl{obfuscated=not_set, bold=not_set, strikethrough=not_set, underlined=not_set, italic=not_set, color=null, shadowColor=null, clickEvent=null, hoverEvent=null, insertion=null, font=null}, children=[]}` à `Redstone block`

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#537 

## Decrivez vos changements
Plutôt que de prendre la clé de traduction pour les items, je la prends en fonction de si c'est un bloc ou pas
