### PR TITLE
Fix la commande /rtp ne fonctionnant pas

### DIFF
--- a/src/main/java/fr/openmc/core/commands/utils/Rtp.java
+++ b/src/main/java/fr/openmc/core/commands/utils/Rtp.java
@@ -56,22 +56,22 @@ public class Rtp {
         new BukkitRunnable() {
             @Override
             public void run() {
-                if (tryRtp(player)) {
-                    DynamicCooldownManager.use(player.getUniqueId().toString(), "player:rtp", 1000L * rtpCooldown);
-                } else {
-                    if ((tries+1) < maxTries) {
-                        player.sendActionBar("RTP: Tentative " + (tries + 1) + "/" + maxTries + " §cÉchec§r...");
-                        new BukkitRunnable() {
-                            @Override
-                            public void run() {
-                                rtpPlayer(player, tries + 1);
-                            }
-                        }.runTaskLaterAsynchronously(OMCPlugin.getInstance(), 20);
-                    } else {
-                        player.sendActionBar("Échec du RTP réessayez plus tard...");
-                        // On a déjà mis le cooldown au début
-                    }
+                if (tryRtp(player))
+                    return;
+
+                if ((tries + 1) >= maxTries) {
+                    // On a déjà mis le cooldown au début
+                    player.sendActionBar("Échec du RTP réessayez plus tard...");
+                    return;
                 }
+
+                player.sendActionBar("RTP: Tentative " + (tries + 1) + "/" + maxTries + " §cÉchec§r...");
+                new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        rtpPlayer(player, tries + 1);
+                    }
+                }.runTaskLaterAsynchronously(OMCPlugin.getInstance(), 20);
             }
         }.runTaskAsynchronously(OMCPlugin.getInstance());
 


### PR DESCRIPTION
## Petit résumé de la PR:
Fix la commande /rtp ne fonctionnant pas

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [x] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#589 

## Decrivez vos changements
Le cooldown était ajouté deux fois au joueur, une fois sync et une autre fois async.
J'ai donc retirée la deuxième fois de façon async
