### PR TITLE
Fix l'avancée de quête quand on craft plusieurs kebabs

### DIFF
--- a/src/main/java/fr/openmc/core/features/quests/quests/CraftKebabQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/CraftKebabQuest.java
@@ -33,7 +33,7 @@ public class CraftKebabQuest extends Quest implements Listener {
     public void onPlayerCraft(CraftItemEvent event) {
         ItemStack item = event.getCurrentItem();
         if (item != null && item.isSimilar(CustomItemRegistry.getByName("omc_foods:kebab").getBest())) {
-            incrementProgress(event.getWhoClicked().getUniqueId());
+            incrementProgress(event.getWhoClicked().getUniqueId(), item.getAmount());
         }
     }
 

--- a/src/main/java/fr/openmc/core/features/quests/quests/CraftKebabQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/CraftKebabQuest.java
@@ -4,8 +4,10 @@ import fr.openmc.core.features.quests.objects.Quest;
 import fr.openmc.core.features.quests.objects.QuestTier;
 import fr.openmc.core.features.quests.rewards.QuestItemReward;
 import fr.openmc.core.features.quests.rewards.QuestMoneyReward;
+import fr.openmc.core.utils.ItemUtils;
 import fr.openmc.core.utils.customitems.CustomItemRegistry;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -33,8 +35,16 @@ public class CraftKebabQuest extends Quest implements Listener {
     public void onPlayerCraft(CraftItemEvent event) {
         ItemStack item = event.getCurrentItem();
         if (item != null && item.isSimilar(CustomItemRegistry.getByName("omc_foods:kebab").getBest())) {
-            incrementProgress(event.getWhoClicked().getUniqueId(), item.getAmount());
+            if (event.isShiftClick()) {
+                int maxCraftable = ItemUtils.getMaxCraftAmount(event.getInventory());
+                int capacity = ItemUtils.getFreePlacesForItem((Player) event.getWhoClicked(), item);
+                maxCraftable = Math.min(maxCraftable, capacity);
+
+                incrementProgress(event.getWhoClicked().getUniqueId(), maxCraftable);
+                return;
+            }
+
+            incrementProgress(event.getWhoClicked().getUniqueId());
         }
     }
-
 }

--- a/src/main/java/fr/openmc/core/features/quests/quests/CraftKebabQuest.java
+++ b/src/main/java/fr/openmc/core/features/quests/quests/CraftKebabQuest.java
@@ -34,17 +34,24 @@ public class CraftKebabQuest extends Quest implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerCraft(CraftItemEvent event) {
         ItemStack item = event.getCurrentItem();
-        if (item != null && item.isSimilar(CustomItemRegistry.getByName("omc_foods:kebab").getBest())) {
-            if (event.isShiftClick()) {
-                int maxCraftable = ItemUtils.getMaxCraftAmount(event.getInventory());
-                int capacity = ItemUtils.getFreePlacesForItem((Player) event.getWhoClicked(), item);
-                maxCraftable = Math.min(maxCraftable, capacity);
+        if (item == null || !item.isSimilar(CustomItemRegistry.getByName("omc_foods:kebab").getBest()))
+            return;
 
-                incrementProgress(event.getWhoClicked().getUniqueId(), maxCraftable);
-                return;
-            }
-
+        // Le joueur ne craft pas plus d'un kebab
+        if (!event.isShiftClick()) {
             incrementProgress(event.getWhoClicked().getUniqueId());
+            return;
         }
+
+        // Calcul le nombre maximum de kebabs pouvant être craftés avec les items dans la table de craft
+        int maxCraftable = ItemUtils.getMaxCraftAmount(event.getInventory());
+        // Calcul le nombre maximum de kebabs que le joueur peut stocker en plus
+        int capacity = ItemUtils.getFreePlacesForItem((Player) event.getWhoClicked(), item);
+
+        maxCraftable = Math.min(maxCraftable, capacity);
+        if (maxCraftable == 0)
+            return;
+
+        incrementProgress(event.getWhoClicked().getUniqueId(), maxCraftable);
     }
 }

--- a/src/main/java/fr/openmc/core/utils/ItemUtils.java
+++ b/src/main/java/fr/openmc/core/utils/ItemUtils.java
@@ -9,6 +9,7 @@ import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Biome;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -107,15 +108,17 @@ public class ItemUtils {
      * @param player Joueur pour acceder a son inventaire
      * @param item Objet concerné
      */
-    public static int getFreePlacesForItem(Player player, ItemStack item){
+    public static int getFreePlacesForItem(Player player, ItemStack item) {
         int stackSize = item.getMaxStackSize();
         int freePlace = stackSize * getSlotNull(player);
 
         Inventory inventory = player.getInventory();
         for (ItemStack stack : inventory.getStorageContents()) {
-            if (stack != null && stack.getType()==item.getType()){
-                if (stack.getAmount() != stackSize) freePlace += stackSize - stack.getAmount();
-            }
+            if (stack == null || !item.isSimilar(stack))
+                continue;
+
+            if (stack.getAmount() != stackSize)
+                freePlace += stackSize - stack.getAmount();
         }
 
         return freePlace;
@@ -218,6 +221,32 @@ public class ItemUtils {
                 }
             }
         }
+    }
+
+    /**
+     * Calcule le nombre maximal d'items pouvant être craftés.
+     * <p>
+     * Cette méthode récupère le résultat du craft. Si le résultat est nul, elle retourne 0.
+     * Sinon, elle détermine le nombre minimal d'items présents dans la grille de craft et
+     * renvoie le produit de la quantité du résultat par ce nombre minimal.
+     *
+     * @param inventory l'inventaire de crafting
+     * @return le nombre maximal d'items pouvant être craftés
+     */
+    public static int getMaxCraftAmount(CraftingInventory inventory) {
+        ItemStack result = inventory.getResult();
+        if (result == null)
+            return 0;
+
+        int resultCount = result.getAmount();
+        int materialCount = Integer.MAX_VALUE;
+
+        for (ItemStack itemStack : inventory.getMatrix()) {
+            if (itemStack != null && itemStack.getAmount() < materialCount)
+                materialCount = itemStack.getAmount();
+        }
+
+        return resultCount * materialCount;
     }
 
     /**


### PR DESCRIPTION
## Petit résumé de la PR:
Fix l'avancée de quête quand on craft plusieurs kebabs

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#602 

## Decrivez vos changements
Maintenant je compte combien de kebabs sont faisable avec les items dans la table de craft pour donner le bon nombre d'avancée au joueur. Tout en calculant combien de kebabs le joueur peut avoir dans son inventaire


https://github.com/user-attachments/assets/895cf696-c15e-4bf2-a327-d466ab05a711


