### PR TITLE
Fix `Cannot invoke "fr.openmc.core.features.city.City.getUUID()" beca…

### DIFF
--- a/src/main/java/fr/openmc/core/features/city/sub/mayor/listeners/UrneListener.java
+++ b/src/main/java/fr/openmc/core/features/city/sub/mayor/listeners/UrneListener.java
@@ -122,6 +122,9 @@ public class UrneListener implements Listener {
         if (!FancyNpcsHook.hasFancyNpc())
             return;
 
+        if (!"omc_blocks:urne".equals(event.getNamespacedID()))
+            return;
+
         Player player = event.getPlayer();
         City playerCity = CityManager.getPlayerCity(player.getUniqueId());
         Location locationMayor = LocationUtils.getSafeNearbySurface(urneLocation.clone().add(2, 0, 0), 2);


### PR DESCRIPTION
## Petit résumé de la PR:
Fix `Cannot invoke "fr.openmc.core.features.city.City.getUUID()" because "playerCity" is null`

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks
- [x] Tester et valider la feature/changement

## Decrivez vos changements
Fix `Cannot invoke "fr.openmc.core.features.city.City.getUUID()" because "playerCity" is null`
