### PR TITLE
Ajout de `/city claim view` pour voir les bordures des claims

### DIFF
--- a/src/main/java/fr/openmc/core/features/city/view/ViewData.java
+++ b/src/main/java/fr/openmc/core/features/city/view/ViewData.java
@@ -1,0 +1,9 @@
+package fr.openmc.core.features.city.view;
+
+import fr.openmc.core.features.city.City;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import org.bukkit.Chunk;
+import org.jetbrains.annotations.NotNull;
+
+public record ViewData(int taskID, @NotNull Object2ObjectMap<Chunk, City> claims) {
+}


### PR DESCRIPTION
## Petit résumé de la PR:
Ajout de `/city claim view` pour voir les bordures des claims grâce à des particules affichées par des packets

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [ ] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [ ] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#707 

## Decrivez vos changements
Ajout d'un ViewManager pour gérer les envoies de packets et modifier le cache des joueurs qui voient les bordures avec le ViewData. Et ajout de la commande `/city claim view`
