### PR TITLE
Fix la perk qui donne de l'aywenite en minant

### DIFF
--- a/src/main/java/fr/openmc/core/features/city/sub/mayor/perks/basic/AyweniterPerk.java
+++ b/src/main/java/fr/openmc/core/features/city/sub/mayor/perks/basic/AyweniterPerk.java
@@ -26,7 +26,7 @@ public class AyweniterPerk implements Listener {
     private static final double DROP_CHANCE = 0.01; //1%
     private final Random random = new Random();
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onBlockBreak(BlockBreakEvent event) {
         Block block = event.getBlock();
         Player player = event.getPlayer();


### PR DESCRIPTION
## Petit résumé de la PR:
Fix la perk AywenitePerk qui donne de l'aywenite en minant de la stone

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
Close #958 

## Decrivez vos changements
J'ai ajouté un ignoreCancelled pour ignorer le fait que le bloc ne veut pas se miner
