### PR TITLE
Fix le cooldown du RTP si il ne tp pas

### DIFF
--- a/src/main/java/fr/openmc/core/commands/utils/RTPCommands.java
+++ b/src/main/java/fr/openmc/core/commands/utils/RTPCommands.java
@@ -54,7 +54,7 @@ public class RTPCommands {
             message = "§cTu dois attendre avant de pouvoir te rtp (%formatTime%)")
     public void rtp(Player player) {
         if (DynamicCooldownManager.isReady(player.getUniqueId(), "player:rtp")) {
-            DynamicCooldownManager.use(player.getUniqueId(), "player:rtp", rtpCooldown * 1000L); // Pour être sûr que le jouer ne réexécute pas la commande avant qu'elle soit finie
+            DynamicCooldownManager.use(player.getUniqueId(), "player:rtp", 15 * 1000L); // Pour être sûr que le jouer ne réexécute pas la commande avant qu'elle soit finie
             rtpPlayer(player, 0);
         }
     }
@@ -110,6 +110,7 @@ public class RTPCommands {
     public void tpPlayer(Player player, Location loc) {
         PlayerUtils.sendFadeTitleTeleport(player, loc);
         MessagesManager.sendMessage(player, Component.text("§aVous avez été téléporté à §6X: §e" + loc.getBlockX() + "§6, Y: §e" + loc.getBlockY() + "§6, Z: §e" + loc.getBlockZ()), Prefix.OPENMC, MessageType.SUCCESS, true);
+        DynamicCooldownManager.use(player.getUniqueId(), "player:rtp", rtpCooldown * 1000L);
     }
 
 }


### PR DESCRIPTION
## Petit résumé de la PR:
Fix le cooldown du RTP si il ne tp pas

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
Close #974 

## Decrivez vos changements
Merci @misieur 
