### PR TITLE
Reset des permissions quand un joueur quitte une ville

### DIFF
--- a/src/main/java/fr/openmc/core/features/city/City.java
+++ b/src/main/java/fr/openmc/core/features/city/City.java
@@ -214,6 +214,7 @@ public class City {
             this.members = CityManager.getCityMembers(this);
 
         members.remove(player);
+        permissions.remove(player);
         Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () ->
             Bukkit.getPluginManager()
                     .callEvent(new MemberLeaveEvent(CacheOfflinePlayer.getOfflinePlayer(player), this))


### PR DESCRIPTION
## Petit résumé de la PR:
Reset des permissions quand un joueur quitte une ville

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
Close #1008 