### PR TITLE
Fix les endermans qui prennent/placent des blocs dans les claims

### DIFF
--- a/src/main/java/fr/openmc/core/features/city/listeners/protections/EntityProtection.java
+++ b/src/main/java/fr/openmc/core/features/city/listeners/protections/EntityProtection.java
@@ -1,10 +1,12 @@
 package fr.openmc.core.features.city.listeners.protections;
 
 import fr.openmc.core.features.city.ProtectionsManager;
+import org.bukkit.entity.Enderman;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
@@ -30,5 +32,11 @@ public class EntityProtection implements Listener {
         if (entity instanceof Merchant || entity instanceof InventoryHolder) {
             ProtectionsManager.verify(player, event, entity.getLocation());
         }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityChangeBlock(EntityChangeBlockEvent event) {
+        if (!(event.getEntity() instanceof Enderman enderman)) return;
+        ProtectionsManager.verify(enderman, event, enderman.getLocation());
     }
 }


### PR DESCRIPTION
## Petit résumé de la PR:
Fix les endermans qui prennent/placent des blocs dans les claims

## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
Close #1044 

## Decrivez vos changements
Juste un event avec un check si c'est un enderman et un `ProtectionsManager.verify`
