### PR TITLE
Empêche les joueurs de mailbox dans la dimension des rêves

### DIFF
--- a/src/main/java/fr/openmc/core/features/mainmenu/menus/Page1.java
+++ b/src/main/java/fr/openmc/core/features/mainmenu/menus/Page1.java
@@ -24,6 +24,7 @@ import fr.openmc.core.features.milestones.menus.MainMilestonesMenu;
 import fr.openmc.core.features.quests.command.QuestCommand;
 import fr.openmc.core.features.settings.command.SettingsCommand;
 import fr.openmc.core.utils.DateUtils;
+import fr.openmc.core.utils.messages.MessageType;
 import fr.openmc.core.utils.messages.MessagesManager;
 import fr.openmc.core.utils.messages.Prefix;
 import net.kyori.adventure.text.Component;
@@ -215,48 +216,24 @@ public class Page1 implements Menu {
             return;
         }
 
+        if (DreamUtils.isInDreamWorld(player)) {
+            PacketMenuLib.closeMenu(player);
+            MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas interagir avec le menu principal depuis le monde des rêves.", NamedTextColor.RED), Prefix.OPENMC, MessageType.ERROR, true);
+            return;
+        }
+
         int slot = event.slot();
         if (CITY_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder à votre ville depuis le monde des rêves."), Prefix.DREAM);
-                return;
-            }
-
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> CityCommands.mainCommand(player));
         } else if (QUEST_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder aux quêtes depuis le monde des rêves."), Prefix.DREAM);
-                return;
-            }
-
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> QuestCommand.onQuest(player));
         } else if (MILESTONES_SLOTS.contains(slot)) {
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> new MainMilestonesMenu(player).open());
         } else if (CONTEST_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder aux contests depuis le monde des rêves."), Prefix.DREAM);
-                return;
-            }
-
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> ContestCommand.mainCommand(player));
         } else if (SHOP_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder aux shops depuis le monde des rêves."), Prefix.DREAM);
-                return;
-            }
-
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> AdminShopManager.openMainMenu(player));
         } else if (HOME_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder à vos homes depuis le monde des rêves."), Prefix.DREAM);
-                return;
-            }
-
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> TpHomeCommand.home(player, null));
         } else if (PROFILE_SLOTS.contains(slot)) {
             PacketMenuLib.closeMenu(player);
@@ -266,12 +243,6 @@ public class Page1 implements Menu {
         } else if (SETTINGS_SLOTS.contains(slot)) {
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> SettingsCommand.settings(player));
         } else if (MAILBOX_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder à votre boîte aux lettres depuis le monde des rêves."), Prefix.DREAM);
-                return;
-            }
-
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> MailboxCommand.homeMailbox(player));
         } else if (ADVANCEMENTS_SLOT == slot) {
             PacketMenuLib.closeMenu(player);

--- a/src/main/java/fr/openmc/core/features/mainmenu/menus/Page2.java
+++ b/src/main/java/fr/openmc/core/features/mainmenu/menus/Page2.java
@@ -154,18 +154,18 @@ public class Page2 implements Menu {
             return;
         }
 
+        if (DreamUtils.isInDreamWorld(player)) {
+            PacketMenuLib.closeMenu(player);
+            MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas interagir avec le menu principal depuis le monde des rêves.", NamedTextColor.RED), Prefix.OPENMC, MessageType.ERROR, true);
+            return;
+        }
+
         int slot = event.slot();
         if (LEFT_ARROW_SLOT == slot) {
             PacketMenuLib.openMenu(new Page1(player), player);
         } else if (SETTINGS_SLOTS.contains(slot)) {
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> SettingsCommand.settings(player));
         } else if (MAILBOX_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder à votre boîte aux lettres depuis le monde des rêves.", NamedTextColor.RED), Prefix.OPENMC, MessageType.ERROR, true);
-                return;
-            }
-
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> MailboxCommand.homeMailbox(player));
         } else if (ADVANCEMENTS_SLOT == slot) {
             PacketMenuLib.closeMenu(player);
@@ -183,24 +183,12 @@ public class Page2 implements Menu {
                 player.sendActionBar(message);
             });
         } else if (COMPANY_SLOTS.contains(slot) || SHOPS_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder aux entreprises ou shops depuis le monde des rêves.", NamedTextColor.RED), Prefix.OPENMC, MessageType.ERROR, true);
-                return;
-            }
-
             MessagesManager.sendMessage(player, Component.text("Les entreprises et shops on été désactivé :sad:.", NamedTextColor.RED), Prefix.OPENMC, MessageType.ERROR, true);
         } else if (LEADERBOARD_SLOTS.contains(slot)) {
             // TODO: Ajouter un menu de classement
             PacketMenuLib.closeMenu(player);
             player.sendMessage(Component.text(FontImageWrapper.replaceFontImages("Le menu de leaderboard est toujours en développement :sad:.\nVous pouvez toujours utiliser le /lb ou regarder les holograms dans le spawn."), NamedTextColor.RED));
         } else if (BANK_SLOTS.contains(slot)) {
-            if (DreamUtils.isInDreamWorld(player)) {
-                PacketMenuLib.closeMenu(player);
-                MessagesManager.sendMessage(player, Component.text("Vous ne pouvez pas accéder à la banque depuis le monde des rêves.", NamedTextColor.RED), Prefix.OPENMC, MessageType.ERROR, true);
-                return;
-            }
-
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> BankCommands.openBankMenu(player));
         } else if (COMING_SOON_1_SLOTS.contains(slot) || COMING_SOON_2_SLOTS.contains(slot)
                 || COMING_SOON_3_SLOTS.contains(slot) || COMING_SOON_4_SLOTS.contains(slot)


### PR DESCRIPTION
## Petit résumé de la PR:
Empêche les joueurs de mailbox dans la dimension des rêves

## Étape nécessaire afin que la PR soit fini (si PR en draft)
- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

## Decrivez vos changements
Ajout d'un `DreamUtils.isInDreamWorld` avec un message
