### PR TITLE
Correctif du détécteur de métaux et de l'apparition des coffres

### DIFF
--- a/src/main/java/fr/openmc/core/features/dream/mecanism/metaldetector/MetalDetectorListener.java
+++ b/src/main/java/fr/openmc/core/features/dream/mecanism/metaldetector/MetalDetectorListener.java
@@ -115,8 +115,8 @@ public class MetalDetectorListener implements Listener {
         Random random = new Random();
 
         for (int i = 0; i < 30; i++) {
-            int dx = random.nextInt(20);
-            int dz = random.nextInt(20);
+            int dx = random.nextInt(41) - 20;
+            int dz = random.nextInt(41) - 20;
             Location tryLoc = origin.clone().add(dx, 0, dz);
             int y = world.getHighestBlockYAt(tryLoc);
             tryLoc.setY(y);
@@ -126,6 +126,6 @@ public class MetalDetectorListener implements Listener {
             }
         }
 
-        return origin.clone().add(5, 0, 5);
+        return origin.clone().add(random.nextInt(41) - 20, 0, random.nextInt(41) - 20);
     }
 }


### PR DESCRIPTION
Fixes #1121

## Problème

`findRandomChestLocation` utilisait `random.nextInt(20)` pour `dx` et `dz`, ce qui donnait uniquement des valeurs positives (0 à +20). Les coffres spawaient donc toujours dans le quadrant nord-est par rapport au joueur.

## Correction

- `dx` et `dz` passent à `random.nextInt(41) - 20` → valeurs entre -20 et +20
- Le fallback (ligne 129) applique le même fix pour être cohérent