### PR TITLE
fix: null check sur getPlayerCity() dans calculatePlayerInterest()

### DIFF
--- a/src/main/java/fr/openmc/core/features/economy/BankManager.java
+++ b/src/main/java/fr/openmc/core/features/economy/BankManager.java
@@ -198,7 +198,8 @@ public class BankManager {
         double interest = .01; // base interest is 1%
 
         if (MayorManager.phaseMayor == 2) {
-            if (PerkManager.hasPerk(CityManager.getPlayerCity(playerUUID).getMayor(), Perks.BUSINESS_MAN.getId())) {
+            City city = CityManager.getPlayerCity(playerUUID);
+            if (city != null && PerkManager.hasPerk(city.getMayor(), Perks.BUSINESS_MAN.getId())) {
                 interest += .02; // interest is +2% when perk Business Man enabled
             }
         }


### PR DESCRIPTION
Corrige le NPE dans `calculatePlayerInterest()` quand un joueur n'appartient à aucune ville.

## Problème

Dans `BankManager.calculatePlayerInterest()`, `CityManager.getPlayerCity(playerUUID)` était appelé sans vérification de `null`, puis `.getMayor()` était directement invoqué dessus. Si le joueur n'a pas de ville, cela provoquait un `NullPointerException` à chaque tick d'intérêt.

## Correction

- Extraction du résultat de `getPlayerCity()` dans une variable locale
- Ajout d'un null check avec short-circuit (`city != null &&`) avant d'accéder à `getMayor()`

Fixes #1166