### PR TITLE
fix: null check sur getPlayerCity() dans calculatePlayerInterest()

### DIFF
--- a/src/main/java/fr/openmc/core/features/economy/BankManager.java
+++ b/src/main/java/fr/openmc/core/features/economy/BankManager.java
@@ -198,7 +198,8 @@ public class BankManager {
         double interest = .01; // base interest is 1%
 
         if (MayorManager.phaseMayor == 2) {
-            if (PerkManager.hasPerk(CityManager.getPlayerCity(playerUUID).getMayor(), Perks.BUSINESS_MAN.getId())) {
+            City city = CityManager.getPlayerCity(playerUUID);
+            if (city != null && PerkManager.hasPerk(city.getMayor(), Perks.BUSINESS_MAN.getId())) {
                 interest += .02; // interest is +2% when perk Business Man enabled
             }
         }


### PR DESCRIPTION
Corrige le `NullPointerException` dans `BankManager.calculatePlayerInterest()` quand un joueur n'appartient à aucune ville.

## Problème

`CityManager.getPlayerCity(playerUUID)` peut retourner `null` si le joueur n'est pas dans une ville. L'appel direct de `.getMayor()` sur le résultat provoquait un `NullPointerException` dans la tâche planifiée `applyAllPlayerInterests`.

## Correction

- Extraction du résultat de `getPlayerCity()` dans une variable locale `city`
- Ajout d'un null check avant d'accéder à `city.getMayor()`

Fixes #1166