### PR TITLE
Correction de la profondeur du Hammer (3x3x3 → 3x3x2)

### DIFF
--- a/src/main/java/fr/openmc/core/registry/items/contents/Hammer.java
+++ b/src/main/java/fr/openmc/core/registry/items/contents/Hammer.java
@@ -36,9 +36,12 @@ public class Hammer extends CustomItem implements BlockBreakableItem {
 
     private static Vector rotateOffset(int x, int y, int z, BlockFace face) {
         return switch (face) {
-            case NORTH, SOUTH -> new Vector(x, y, z);
-            case EAST, WEST -> new Vector(z, y, x);
-            case UP, DOWN -> new Vector(x, z, y);
+            case SOUTH -> new Vector(x, y, z);
+            case NORTH -> new Vector(x, y, -z);
+            case EAST -> new Vector(z, y, x);
+            case WEST -> new Vector(-z, y, x);
+            case UP -> new Vector(x, z, y);
+            case DOWN -> new Vector(x, -z, y);
             default -> new Vector(0, 0, 0);
         };
     }
@@ -51,7 +54,7 @@ public class Hammer extends CustomItem implements BlockBreakableItem {
 
         for (int dx = -radius; dx <= radius; dx++) {
             for (int dy = -radius; dy <= radius; dy++) {
-                for (int dz = -depth; dz <= depth; dz++) {
+                for (int dz = 0; dz <= depth; dz++) {
 
                     if (dx == 0 && dy == 0 && dz == 0) continue;
 


### PR DESCRIPTION
Corrige le bug où le Hammer en diamant minait en 3×3×3 au lieu de 3×3×2.

## Problème

Dans `Hammer.breakArea()`, la boucle de profondeur (`dz`) allait de `-depth` à `+depth`, minant des blocs dans les deux directions par rapport à la face frappée. De plus, `rotateOffset()` ne différenciait pas les directions opposées (NORTH/SOUTH partageaient le même vecteur), ce qui rendait impossible la correction via la boucle seule.

## Correction

- Boucle `dz` changée de `-depth..depth` → `0..depth` pour ne miner que dans une seule direction
- `rotateOffset()` gère maintenant chaque face individuellement avec le bon signe, garantissant que la profondeur va toujours dans la direction correcte (vers l'intérieur du bloc miné)

Fixes #1151