### PR TITLE
Correctif des lettres qui n'étaient pas récupérable à certains moments

### DIFF
--- a/src/main/java/fr/openmc/core/OMCPlugin.java
+++ b/src/main/java/fr/openmc/core/OMCPlugin.java
@@ -132,8 +132,9 @@ public class OMCPlugin extends JavaPlugin {
         TPAQueue.initCommand();
         FreezeManager.init();
         QuestProgressSaveManager.init();
-        if (!isUnitTestVersion())
+        if (!isUnitTestVersion()) {
             TabList.init();
+        }
         AdminShopManager.init();
         BossbarManager.init();
         AnimationsManager.init();

--- a/src/main/java/fr/openmc/core/features/mailboxes/menu/letter/LetterMenu.java
+++ b/src/main/java/fr/openmc/core/features/mailboxes/menu/letter/LetterMenu.java
@@ -15,7 +15,6 @@ import fr.openmc.core.utils.messages.MessagesManager;
 import fr.openmc.core.utils.messages.Prefix;
 import fr.openmc.core.utils.serializer.BukkitSerializer;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -35,6 +34,7 @@ import static fr.openmc.core.utils.InputUtils.pluralize;
 public class LetterMenu extends Menu {
     private final Letter letter;
     private final LetterHead letterHead;
+    private ItemStack[] resolvedItems;
 
     @Override
     public @NotNull String getName() {
@@ -82,7 +82,15 @@ public class LetterMenu extends Menu {
     }
 
     public void accept() {
+        ItemStack[] items = resolveItems();
+
         if (MailboxManager.deleteLetter(letterHead.getLetterId())) {
+            HashMap<Integer, ItemStack> remainingItems = getOwner().getInventory().addItem(items);
+            World world = getOwner().getWorld();
+            for (ItemStack item : remainingItems.values()) {
+                world.dropItemNaturally(getOwner().getLocation(), item);
+            }
+
             MessagesManager.sendMessage(
                     getOwner(),
                     Component.text("Vous avez reçu ", NamedTextColor.DARK_GREEN)
@@ -94,14 +102,8 @@ public class LetterMenu extends Menu {
             );
 
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () ->
-                    Bukkit.getPluginManager().callEvent(new ClaimLetterEvent(getOwner(), MailboxManager.getById(getOwner(), letterHead.getLetterId())))
+                    Bukkit.getPluginManager().callEvent(new ClaimLetterEvent(getOwner(), letter))
             );
-
-            HashMap<Integer, ItemStack> remainingItems = getOwner().getInventory().addItem(letter.getCachedItems());
-            World world = getOwner().getWorld();
-            for (ItemStack item : remainingItems.values()) {
-                world.dropItemNaturally(getOwner().getLocation(), item);
-            }
         } else {
             Component message = Component.text("La lettre avec l'id ", NamedTextColor.DARK_RED)
                     .append(Component.text(letterHead.getLetterId(), NamedTextColor.RED))
@@ -132,15 +134,11 @@ public class LetterMenu extends Menu {
     public @NotNull Map<Integer, ItemBuilder> getContent() {
         Map<Integer, ItemBuilder> content = new HashMap<>();
 
-        ItemStack[] items = letter.getCachedItems();
+        ItemStack[] items = resolveItems();
 
-        if (items == null || items.length == 0) {
-            byte[] serializedItems = letter.getItems();
-            items = serializedItems != null ? BukkitSerializer.deserializeItemStacks(serializedItems) : new ItemStack[0];
-        }
-
-        for (int i = 0; i < items.length; i++)
+        for (int i = 0; i < items.length; i++) {
             content.put(i + 9, new ItemBuilder(this, items[i]));
+        }
 
         content.put(45, homeBtn(this));
         content.put(48, acceptBtn(this).setOnClick(e -> accept()));
@@ -162,6 +160,17 @@ public class LetterMenu extends Menu {
                 MessageType.ERROR,
                 true
         );
+    }
+
+    private ItemStack[] resolveItems() {
+        if (resolvedItems != null) return resolvedItems;
+        ItemStack[] items = letter.getCachedItems();
+        if (items == null || items.length == 0) {
+            byte[] serializedItems = letter.getItems();
+            items = serializedItems != null ? BukkitSerializer.deserializeItemStacks(serializedItems) : new ItemStack[0];
+        }
+        resolvedItems = items;
+        return items;
     }
 
     @Override


### PR DESCRIPTION
Corrige le bug où les items de la mailbox disparaissaient lors de l'acceptation d'une lettre.

## Problème

Dans `LetterMenu.accept()`, les items étaient récupérés **après** `deleteLetter()`, qui supprime la lettre du cache en mémoire. `MailboxManager.getById()` retournait alors `null` dans le `ClaimLetterEvent`, et `letter.getCachedItems()` pouvait échouer silencieusement — les items étaient perdus sans message d'erreur.

Le problème se manifestait principalement quand l'expéditeur était déconnecté et que la lettre avait été envoyée avant un redémarrage serveur.

## Correction

- Extraction d'une méthode `resolveItems()` qui cache les items désérialisés dans un champ `resolvedItems`, évitant la double désérialisation entre `getContent()` et `accept()`
- Appel de `resolveItems()` **avant** `deleteLetter()` pour garantir que les items sont disponibles
- Les items sont donnés au joueur **avant** le fire du `ClaimLetterEvent`
- `ClaimLetterEvent` reçoit directement l'objet `letter` au lieu de `getById()` post-suppression

Fixes #1167, fixes #1084