### PR TITLE
Correctif où la singularité ne pouvait pas etre ouvrir sans regarder de bloc

### DIFF
--- a/src/main/java/fr/openmc/core/listeners/InteractListener.java
+++ b/src/main/java/fr/openmc/core/listeners/InteractListener.java
@@ -17,8 +17,6 @@ public class InteractListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     void onInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
-        if (event.useInteractedBlock() == Event.Result.DENY) return;
-
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
         CustomItem item = CustomItemRegistry.getByItemStack(itemInHand);
 


### PR DESCRIPTION
Corrige le bug où la singularité ne pouvait pas être utilisée sans regarder un bloc.

## Problème

Dans `InteractListener.onInteract()`, un check `event.useInteractedBlock() == Event.Result.DENY` provoquait un `return` immédiat lorsque le joueur ne regardait aucun bloc. Cela empêchait tout item custom implémentant `UsableItem` (comme la Singularité) de fonctionner en l'air.

## Correction

- Suppression du check `useInteractedBlock() == DENY` qui bloquait inutilement l'événement pour les items custom

Fixes #1213