### PR TITLE
Correctif de la Singularité/Meteo Wand où on pouvait pas cliquer dans l'air

### DIFF
--- a/src/main/java/fr/openmc/core/features/dream/mecanism/metaldetector/MetalDetectorListener.java
+++ b/src/main/java/fr/openmc/core/features/dream/mecanism/metaldetector/MetalDetectorListener.java
@@ -1,32 +1,16 @@
 package fr.openmc.core.features.dream.mecanism.metaldetector;
 
 import fr.openmc.core.OMCPlugin;
-import fr.openmc.core.features.dream.DreamUtils;
-import fr.openmc.core.features.dream.events.MetalDetectorLootEvent;
 import fr.openmc.core.features.dream.generation.DreamBiome;
-import fr.openmc.core.registry.loottable.CustomLootTable;
-import fr.openmc.core.utils.LocationUtils;
-import fr.openmc.core.utils.messages.MessageType;
-import fr.openmc.core.utils.messages.MessagesManager;
-import fr.openmc.core.utils.messages.Prefix;
-import net.kyori.adventure.text.Component;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.ItemStack;
 
-import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
@@ -55,44 +39,6 @@ public class MetalDetectorListener implements Listener {
 
         if (hiddenChests.containsKey(uuid))
             hiddenChests.remove(uuid).cancel();
-    }
-
-    @EventHandler
-    public void onChestClick(PlayerInteractEvent event) {
-        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
-        if (event.getHand() != EquipmentSlot.HAND) return;
-
-        Block clicked = event.getClickedBlock();
-        if (clicked == null) return;
-
-        if (!DreamUtils.isDreamWorld(event.getClickedBlock().getLocation())) return;
-        Player player = event.getPlayer();
-        UUID uuid = player.getUniqueId();
-        if (!hiddenChests.containsKey(uuid)) return;
-
-        if (clicked.getType() == Material.CHEST) {
-            event.setCancelled(true);
-            MetalDetectorTask task = hiddenChests.remove(uuid);
-            task.cancel();
-            Location chestLoc = task.getChestLocation();
-
-            if (LocationUtils.isSameLocation(clicked.getLocation(), chestLoc)) {
-                event.setCancelled(true);
-                clicked.setType(Material.MUD);
-                CustomLootTable lootTable = MetalDetectorManager.METAL_DETECTOR_LOOT_TABLE;
-                if (lootTable == null) return;
-                List<ItemStack> rewards = lootTable.rollLoots();
-
-                for (ItemStack item : rewards) {
-                    player.getInventory().addItem(item);
-                }
-
-                Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () ->
-                        Bukkit.getServer().getPluginManager().callEvent(new MetalDetectorLootEvent(player, rewards))
-                );
-                MessagesManager.sendMessage(player, Component.text("Vous avez découvert §e" + rewards.size() + " §fobjet(s) dans vos rêves !"), Prefix.DREAM, MessageType.SUCCESS, false);
-            }
-        }
     }
 
     @EventHandler

--- a/src/main/java/fr/openmc/core/features/dream/registries/items/tools/MetalDetector.java
+++ b/src/main/java/fr/openmc/core/features/dream/registries/items/tools/MetalDetector.java
@@ -2,21 +2,28 @@ package fr.openmc.core.features.dream.registries.items.tools;
 
 import fr.openmc.core.OMCPlugin;
 import fr.openmc.core.features.dream.DreamUtils;
+import fr.openmc.core.features.dream.events.MetalDetectorLootEvent;
+import fr.openmc.core.features.dream.mecanism.metaldetector.MetalDetectorManager;
 import fr.openmc.core.features.dream.mecanism.metaldetector.MetalDetectorTask;
 import fr.openmc.core.features.dream.models.registry.items.DreamItem;
 import fr.openmc.core.features.dream.models.registry.items.DreamRarity;
 import fr.openmc.core.registry.items.options.UsableItem;
+import fr.openmc.core.registry.loottable.CustomLootTable;
+import fr.openmc.core.utils.LocationUtils;
 import fr.openmc.core.utils.messages.MessageType;
 import fr.openmc.core.utils.messages.MessagesManager;
 import fr.openmc.core.utils.messages.Prefix;
 import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.List;
 import java.util.UUID;
 
 import static fr.openmc.core.features.dream.mecanism.metaldetector.MetalDetectorListener.findRandomChestLocation;
@@ -48,6 +55,40 @@ public class MetalDetector extends DreamItem implements UsableItem {
 
         item.getItemMeta().itemName(Component.text("Détecteur à métaux"));
         return item;
+    }
+
+    @Override
+    public void onRightClick(Player player, PlayerInteractEvent event) {
+        Block clicked = event.getClickedBlock();
+        if (clicked == null) return;
+
+        if (!DreamUtils.isDreamWorld(event.getClickedBlock().getLocation())) return;
+        UUID uuid = player.getUniqueId();
+        if (!hiddenChests.containsKey(uuid)) return;
+
+        if (clicked.getType() == Material.CHEST) {
+            event.setCancelled(true);
+            MetalDetectorTask task = hiddenChests.remove(uuid);
+            task.cancel();
+            Location chestLoc = task.getChestLocation();
+
+            if (LocationUtils.isSameLocation(clicked.getLocation(), chestLoc)) {
+                event.setCancelled(true);
+                clicked.setType(Material.MUD);
+                CustomLootTable lootTable = MetalDetectorManager.METAL_DETECTOR_LOOT_TABLE;
+                if (lootTable == null) return;
+                List<ItemStack> rewards = lootTable.rollLoots();
+
+                for (ItemStack item : rewards) {
+                    player.getInventory().addItem(item);
+                }
+
+                Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () ->
+                        Bukkit.getServer().getPluginManager().callEvent(new MetalDetectorLootEvent(player, rewards))
+                );
+                MessagesManager.sendMessage(player, Component.text("Vous avez découvert §e" + rewards.size() + " §fobjet(s) dans vos rêves !"), Prefix.DREAM, MessageType.SUCCESS, false);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/fr/openmc/core/listeners/InteractListener.java
+++ b/src/main/java/fr/openmc/core/listeners/InteractListener.java
@@ -4,7 +4,6 @@ import fr.openmc.core.registry.items.CustomItem;
 import fr.openmc.core.registry.items.CustomItemRegistry;
 import fr.openmc.core.registry.items.options.UsableItem;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -14,10 +13,9 @@ import org.bukkit.inventory.ItemStack;
 
 public class InteractListener implements Listener {
 
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOWEST)
     void onInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
-        if (event.useInteractedBlock() == Event.Result.DENY) return;
 
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
         CustomItem item = CustomItemRegistry.getByItemStack(itemInHand);


### PR DESCRIPTION
## Petit résumé de la PR:
La suppression de ignoreCancelled = true n'a aucun effet spécifiquement sur les UsableItem, sur les outils pouvant casser des blocs comme Hammer ect sont obligatoires pour eviter de casser dans les claims.
Or ici les UsableItem implémentés, jusqu'a ici ne modifie pas le terrain.

j'ai changé un truc totalement stupide de ma part sur le MetalDetector ahaha
## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [ ] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [ ] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->
