### PR TITLE
Correction de la couleur blanche mise par défaut sur le component argument

### DIFF
--- a/src/main/java/fr/openmc/core/utils/text/ComponentUtils.java
+++ b/src/main/java/fr/openmc/core/utils/text/ComponentUtils.java
@@ -2,7 +2,6 @@ package fr.openmc.core.utils.text;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 
 public class ComponentUtils {
@@ -23,7 +22,7 @@ public class ComponentUtils {
                 continue;
             }
             Component component = like.asComponent();
-            normalized[i] = component.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE).colorIfAbsent(NamedTextColor.WHITE);
+            normalized[i] = component.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE);
         }
         return normalized;
     }


### PR DESCRIPTION
j'avais pas testé mais comme le component argument n'a pas la couleur des parents, et donc je force une couleur (WHITE dans ce cas) et ça empeche la couleur du component parent

## Petit résumé de la PR:


## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [ ] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [ ] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->
