### PR TITLE
Correctif des améliorations des homes

### DIFF
--- a/src/main/java/fr/openmc/core/features/homes/HomeUpgradeManager.java
+++ b/src/main/java/fr/openmc/core/features/homes/HomeUpgradeManager.java
@@ -17,7 +17,7 @@ import org.bukkit.entity.Player;
 public class HomeUpgradeManager {
 
     public static HomeLimits getCurrentUpgrade(Player player) {
-        int currentLimit = HomesManager.getHomeLimit(player.getUniqueId());
+        int currentLimit = HomesManager.getHomeLimit(player.getUniqueId()).getLimit();
         for (HomeLimits upgrade : HomeLimits.values()) {
             if (upgrade.getLimit() == currentLimit) {
                 return upgrade;
@@ -27,12 +27,20 @@ public class HomeUpgradeManager {
     }
 
     public static HomeLimits getNextUpgrade(HomeLimits current) {
-        return HomeLimits.values()[current.ordinal() + 1];
+        if (current == null)
+            return null;
+
+        HomeLimits[] values = HomeLimits.values();
+        int nextIndex = current.ordinal() + 1;
+        if (nextIndex >= values.length)
+            return null;
+
+        return values[nextIndex];
     }
 
     public static void upgradeHome(Player player) {
         int currentHomes = HomesManager.getHomes(player.getUniqueId()).size();
-        int currentUpgrade = HomesManager.getHomeLimit(player.getUniqueId());
+        int currentUpgrade = HomesManager.getHomeLimit(player.getUniqueId()).getLimit();
         HomeLimits nextUpgrade = getNextUpgrade(getCurrentUpgrade(player));
         if(nextUpgrade != null) {
             int price = nextUpgrade.getPrice();
@@ -83,7 +91,7 @@ public class HomeUpgradeManager {
 
             HomesManager.updateHomeLimit(player.getUniqueId());
 
-            int updatedHomesLimit = HomesManager.getHomeLimit(player.getUniqueId());
+            int updatedHomesLimit = HomesManager.getHomeLimit(player.getUniqueId()).getLimit();
 
             Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), () -> {
                 Bukkit.getPluginManager().callEvent(new HomeUpgradeEvent(player));

--- a/src/main/java/fr/openmc/core/features/homes/HomesManager.java
+++ b/src/main/java/fr/openmc/core/features/homes/HomesManager.java
@@ -86,7 +86,7 @@ public class HomesManager extends Feature implements DatabaseFeature, HasCommand
                 .toList();
     }
 
-    public static int getHomeLimit(UUID playerUUID) {
+    public static HomeLimits getHomeLimit(UUID playerUUID) {
         HomeLimit homeLimit = homeLimits.stream()
                 .filter(hl -> hl.getPlayerUUID().equals(playerUUID))
                 .findFirst()
@@ -97,7 +97,7 @@ public class HomesManager extends Feature implements DatabaseFeature, HasCommand
             homeLimits.add(homeLimit);
         }
 
-        return homeLimit.getLimit();
+        return homeLimit.getHomeLimit();
     }
 
     public static void updateHomeLimit(UUID playerUUID) {

--- a/src/main/java/fr/openmc/core/features/homes/command/SetHomeCommand.java
+++ b/src/main/java/fr/openmc/core/features/homes/command/SetHomeCommand.java
@@ -104,7 +104,7 @@ public class SetHomeCommand {
         }
 
         int currentHome = HomesManager.getHomes(player.getUniqueId()).size();
-        int homesLimit = HomesManager.getHomeLimit(player.getUniqueId());
+        int homesLimit = HomesManager.getHomeLimit(player.getUniqueId()).getLimit();
 
         if(currentHome >= homesLimit) {
             MessagesManager.sendMessage(player, TranslationManager.translation("feature.homes.command.home_limit_reached"), Prefix.HOME, MessageType.ERROR, true);

--- a/src/main/java/fr/openmc/core/features/homes/menu/HomeUpgradeMenu.java
+++ b/src/main/java/fr/openmc/core/features/homes/menu/HomeUpgradeMenu.java
@@ -9,7 +9,6 @@ import fr.openmc.core.features.economy.EconomyManager;
 import fr.openmc.core.features.homes.HomeLimits;
 import fr.openmc.core.features.homes.HomeUpgradeManager;
 import fr.openmc.core.features.homes.HomesManager;
-import fr.openmc.core.registry.items.CustomItemRegistry;
 import fr.openmc.core.utils.text.messages.TranslationManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -44,36 +43,31 @@ public class HomeUpgradeMenu extends Menu {
     public @NotNull Map<Integer, ItemBuilder> getContent() {
         Map<Integer, ItemBuilder> items = new HashMap<>();
 
-        int currentHome = HomesManager.getHomeLimit(getOwner().getUniqueId());
+        int currentHome = HomesManager.getHomeLimit(getOwner().getUniqueId()).getLimit();
 
-        int homeMaxLimit = HomeLimits.values().length - 1;
+        HomeLimits nextUpgrade = HomeUpgradeManager.getNextUpgrade(HomeUpgradeManager.getCurrentUpgrade(getOwner()));
 
-            HomeLimits lastUpgrade = HomeLimits.valueOf("LIMIT_" + homeMaxLimit);
-            HomeLimits nextUpgrade = HomeUpgradeManager.getNextUpgrade(HomeUpgradeManager.getCurrentUpgrade(getOwner())) != null
-                    ? HomeUpgradeManager.getNextUpgrade(HomeUpgradeManager.getCurrentUpgrade(getOwner()))
-                    : lastUpgrade;
-
-            items.put(4, new ItemBuilder(this, Objects.requireNonNull(OMCRegistry.CUSTOM_ITEMS.get("omc_homes:omc_homes_icon_upgrade")).getBest(), itemMeta -> {
-                itemMeta.displayName(TranslationManager.translation("feature.homes.upgrade.item.name"));
-                if (nextUpgrade.getLimit() >= lastUpgrade.getLimit()) {
-                    itemMeta.lore(TranslationManager.translationLore(
-                            "feature.homes.upgrade.lore.max",
-                            Component.text(currentHome).color(NamedTextColor.YELLOW)
-                    ));
-                } else {
-                    itemMeta.lore(TranslationManager.translationLore(
-                            "feature.homes.upgrade.lore.available",
-                            Component.text(currentHome).color(NamedTextColor.YELLOW),
-                            Component.text(nextUpgrade.getPrice()).color(NamedTextColor.GREEN),
-                            Component.text(EconomyManager.getEconomyIcon()).decoration(TextDecoration.ITALIC, false),
-                            Component.text(nextUpgrade.getAyweniteCost()).color(NamedTextColor.LIGHT_PURPLE),
-                            Component.text(nextUpgrade.getLimit()).color(NamedTextColor.YELLOW)
-                    ));
-                }
-            }).setOnClick(event -> {
-                HomeUpgradeManager.upgradeHome(getOwner());
-                getOwner().closeInventory();
-            }));
+        items.put(4, new ItemBuilder(this, Objects.requireNonNull(OMCRegistry.CUSTOM_ITEMS.get("omc_homes:omc_homes_icon_upgrade")).getBest(), itemMeta -> {
+            itemMeta.displayName(TranslationManager.translation("feature.homes.upgrade.item.name"));
+            if (nextUpgrade == null) {
+                itemMeta.lore(TranslationManager.translationLore(
+                        "feature.homes.upgrade.lore.max",
+                        Component.text(currentHome).color(NamedTextColor.YELLOW)
+                ));
+            } else {
+                itemMeta.lore(TranslationManager.translationLore(
+                        "feature.homes.upgrade.lore.available",
+                        Component.text(currentHome).color(NamedTextColor.YELLOW),
+                        Component.text(nextUpgrade.getPrice()).color(NamedTextColor.GREEN),
+                        Component.text(EconomyManager.getEconomyIcon()).decoration(TextDecoration.ITALIC, false),
+                        Component.text(nextUpgrade.getAyweniteCost()).color(NamedTextColor.LIGHT_PURPLE),
+                        Component.text(nextUpgrade.getLimit()).color(NamedTextColor.YELLOW)
+                ));
+            }
+        }).setOnClick(event -> {
+            HomeUpgradeManager.upgradeHome(getOwner());
+            getOwner().closeInventory();
+        }));
 
         return items;
     }

--- a/src/main/java/fr/openmc/core/features/homes/models/HomeLimit.java
+++ b/src/main/java/fr/openmc/core/features/homes/models/HomeLimit.java
@@ -1,13 +1,12 @@
 package fr.openmc.core.features.homes.models;
 
-import java.util.UUID;
-
 import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
-
 import fr.openmc.core.features.homes.HomeLimits;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.UUID;
 
 @Getter
 @DatabaseTable(tableName = "home_limits")
@@ -34,11 +33,16 @@ public class HomeLimit {
     }
 
     public HomeLimits getHomeLimit() {
+        HomeLimits minHomeLimit = HomeLimits.LIMIT_0;
         for (HomeLimits value : HomeLimits.values()) {
             if (value.getLimit() == this.limit) {
                 return value;
             }
+            if (value.getLimit() < this.limit) {
+                minHomeLimit = value;
+            }
         }
-        return null;
+
+        return minHomeLimit;
     }
 }


### PR DESCRIPTION
## Petit résumé de la PR:
Le bug était que si le homeLimit était de 2, (mis par un admin humm moi).
ben le programme tentait d'avoir un HomeLimits (enum) correspondant au nombre précis de homeLimit.
or si il le trouve pas il renvoie null et ça arretais forcément l'upgrade. 

## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [ ] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [ ] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->
