### PR TITLE
Ajoute de cooldown de téléportation lors des combats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,69 @@ tasks.shadowJar {
     relocate("revxrsal.commands", "fr.openmc.shaded.revxrsal.commands")
     relocate("com.j256.ormlite", "fr.openmc.shaded.com.j256.ormlite")
 }
+def serverJar = file("run/paper.jar")
+def paperUrl = "https://fill-data.papermc.io/v1/objects/8600cc3b91ea38d7e836d562550b31d0fa3ed785d14dffc1a6d9dc1d36c21fa5/paper-26.2-56.jar"
+
+tasks.register("runDevServer") {
+    dependsOn shadowJar
+
+    doLast {
+        mkdir("run")
+        mkdir("run/plugins")
+
+        if (!serverJar.exists()) {
+            println("Téléchargement de Paper...")
+
+            new URL(paperUrl).withInputStream { input ->
+                serverJar.withOutputStream { output ->
+                    output << input
+                }
+            }
+        }
+
+        copy {
+            from shadowJar.archiveFile
+            into "run/plugins"
+            rename { "OpenMC.jar" }
+        }
+
+        def javaExe = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(targetJavaVersion)
+        }.get().executablePath.asFile.absolutePath
+
+        def process = new ProcessBuilder(
+                javaExe,
+                "-Xms2G",
+                "-Xmx2G",
+                "-jar",
+                serverJar.name,
+                "--nogui"
+        )
+                .directory(file("run"))
+                .redirectErrorStream(true)
+                .start()
+
+            Thread.start {
+            process.inputStream.eachLine {
+                println(it)
+            }
+        }
+
+        Thread.start {
+            def writer = new BufferedWriter(new OutputStreamWriter(process.outputStream))
+            System.in.withReader { reader ->
+                String line
+                while ((line = reader.readLine()) != null) {
+                    writer.write(line)
+                    writer.newLine()
+                    writer.flush()
+                }
+            }
+        }
+
+        process.waitFor()
+    }
+}
 
 tasks.test {
     useJUnitPlatform()

--- a/src/main/java/fr/openmc/core/ListenersManager.java
+++ b/src/main/java/fr/openmc/core/ListenersManager.java
@@ -2,9 +2,24 @@ package fr.openmc.core;
 
 import fr.openmc.api.input.ChatInput;
 import fr.openmc.api.input.location.ItemInteraction;
+import fr.openmc.core.features.combat.CombatCooldownListener;
 import fr.openmc.core.features.itemsadder.SpawnerExtractorListener;
 import fr.openmc.core.hooks.itemsadder.ItemsAdderHook;
-import fr.openmc.core.listeners.*;
+import fr.openmc.core.listeners.ArmorListener;
+import fr.openmc.core.listeners.AsyncChatListener;
+import fr.openmc.core.listeners.BlockBreakListener;
+import fr.openmc.core.listeners.BlockPlaceListener;
+import fr.openmc.core.listeners.ChronometerListener;
+import fr.openmc.core.listeners.ClockInfos;
+import fr.openmc.core.listeners.EquipableItemListener;
+import fr.openmc.core.listeners.HappyGhastListener;
+import fr.openmc.core.listeners.InteractListener;
+import fr.openmc.core.listeners.ItemsAddersListener;
+import fr.openmc.core.listeners.JoinQuitMessageListener;
+import fr.openmc.core.listeners.NoMoreRabbit;
+import fr.openmc.core.listeners.PlayerDeathListener;
+import fr.openmc.core.listeners.SessionsListener;
+import fr.openmc.core.listeners.SleepListener;
 import fr.openmc.core.registry.ambient.listeners.AmbientWeatherListener;
 import fr.openmc.core.registry.ambient.listeners.BiomesOnChunkLoad;
 import fr.openmc.core.registry.ambient.listeners.CustomAmbientListener;
@@ -24,6 +39,7 @@ public class ListenersManager {
     public static void init() {
         registerEvents(
                 new HappyGhastListener(),
+                new CombatCooldownListener(),
                 new SessionsListener(),
                 new JoinQuitMessageListener(),
                 new ClockInfos(),

--- a/src/main/java/fr/openmc/core/commands/utils/RTPCommands.java
+++ b/src/main/java/fr/openmc/core/commands/utils/RTPCommands.java
@@ -115,7 +115,9 @@ public class RTPCommands {
     }
 
     private void tpPlayer(Player player, Location loc) {
-        PlayerUtils.sendFadeTitleTeleport(player, loc);
+        if (!PlayerUtils.sendFadeTitleTeleport(player, loc)) {
+            return;
+        }
         MessagesManager.sendMessage(player, TranslationManager.translation("command.utils.rtp.success",
                         Component.text(loc.getBlockX()).color(YELLOW),
                         Component.text(loc.getBlockY()).color(YELLOW),

--- a/src/main/java/fr/openmc/core/commands/utils/Spawn.java
+++ b/src/main/java/fr/openmc/core/commands/utils/Spawn.java
@@ -11,7 +11,11 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import revxrsal.commands.annotation.*;
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.Description;
+import revxrsal.commands.annotation.Named;
+import revxrsal.commands.annotation.Optional;
+import revxrsal.commands.annotation.SuggestWith;
 import revxrsal.commands.bukkit.annotation.CommandPermission;
 
 public class Spawn {
@@ -27,12 +31,16 @@ public class Spawn {
         Location spawnLocation = SpawnManager.getSpawnLocation();
 
         if (sender instanceof Player player && (target == null || player.getUniqueId().equals(target.getUniqueId()))) {
-            PlayerUtils.sendFadeTitleTeleport(player, spawnLocation);
+            if (!PlayerUtils.sendFadeTitleTeleport(player, spawnLocation)) {
+                return;
+            }
             MessagesManager.sendMessage(player, TranslationManager.translation("command.utils.spawn.got_sent"),
                     Prefix.OPENMC, MessageType.SUCCESS, true);
         } else {
             if(!(sender instanceof Player) || sender.hasPermission("omc.admin.commands.spawn.others")) {
-                PlayerUtils.sendFadeTitleTeleport(target, spawnLocation);
+                if (!PlayerUtils.sendFadeTitleTeleport(target, spawnLocation)) {
+                    return;
+                }
                 MessagesManager.sendMessage(sender, TranslationManager.translation("command.utils.spawn.have_sent",
                         Component.text(target.getName()).color(NamedTextColor.YELLOW)), Prefix.OPENMC, MessageType.SUCCESS, true);
                 MessagesManager.sendMessage(target, TranslationManager.translation("command.utils.spawn.have_sent_by",

--- a/src/main/java/fr/openmc/core/features/combat/CombatCooldownListener.java
+++ b/src/main/java/fr/openmc/core/features/combat/CombatCooldownListener.java
@@ -1,0 +1,33 @@
+package fr.openmc.core.features.combat;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public final class CombatCooldownListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerHit(EntityDamageByEntityEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        if (!(event.getDamager() instanceof Player)) {
+            return;
+        }
+
+        if (event.getFinalDamage() <= 0) {
+            return;
+        }
+
+        CombatCooldownManager.recordHit(player.getUniqueId());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        CombatCooldownManager.clear(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/fr/openmc/core/features/combat/CombatCooldownManager.java
+++ b/src/main/java/fr/openmc/core/features/combat/CombatCooldownManager.java
@@ -1,0 +1,37 @@
+package fr.openmc.core.features.combat;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class CombatCooldownManager {
+
+    private static final long COMBAT_COOLDOWN_MILLIS = Duration.ofSeconds(10).toMillis();
+    private static final ConcurrentHashMap<UUID, Long> LAST_HIT_TIMES = new ConcurrentHashMap<>();
+
+    private CombatCooldownManager() {
+    }
+
+    public static void recordHit(UUID playerId) {
+        LAST_HIT_TIMES.put(playerId, System.currentTimeMillis());
+    }
+
+    public static long getRemainingSeconds(UUID playerId) {
+        Long lastHitTime = LAST_HIT_TIMES.get(playerId);
+        if (lastHitTime == null) {
+            return 0;
+        }
+
+        long remainingMillis = lastHitTime + COMBAT_COOLDOWN_MILLIS - System.currentTimeMillis();
+        if (remainingMillis <= 0) {
+            LAST_HIT_TIMES.remove(playerId, lastHitTime);
+            return 0;
+        }
+
+        return Math.ceilDiv(remainingMillis, 1000L);
+    }
+
+    public static void clear(UUID playerId) {
+        LAST_HIT_TIMES.remove(playerId);
+    }
+}

--- a/src/main/java/fr/openmc/core/features/homes/command/TpHomeCommand.java
+++ b/src/main/java/fr/openmc/core/features/homes/command/TpHomeCommand.java
@@ -18,7 +18,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
-import revxrsal.commands.annotation.*;
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.Description;
+import revxrsal.commands.annotation.Named;
+import revxrsal.commands.annotation.Optional;
+import revxrsal.commands.annotation.SuggestWith;
 import revxrsal.commands.bukkit.annotation.CommandPermission;
 
 import java.util.List;
@@ -59,7 +63,9 @@ public class TpHomeCommand {
 
             for(Home h : homes) {
                 if (h.getName().equalsIgnoreCase(split[1])) {
-                    PlayerUtils.sendFadeTitleTeleport(player, h.getLocation());
+                    if (!PlayerUtils.sendFadeTitleTeleport(player, h.getLocation())) {
+                        return;
+                    }
                     new BukkitRunnable() {
                         @Override
                         public void run() {
@@ -100,7 +106,9 @@ public class TpHomeCommand {
 
         for(Home h : homes) {
             if(h.getName().equalsIgnoreCase(home)) {
-                PlayerUtils.sendFadeTitleTeleport(player, h.getLocation());
+                if (!PlayerUtils.sendFadeTitleTeleport(player, h.getLocation())) {
+                    return;
+                }
                 new BukkitRunnable() {
                     @Override
                     public void run() {

--- a/src/main/java/fr/openmc/core/features/homes/menu/HomeMenu.java
+++ b/src/main/java/fr/openmc/core/features/homes/menu/HomeMenu.java
@@ -13,6 +13,7 @@ import fr.openmc.core.features.homes.events.HomeTpEvent;
 import fr.openmc.core.features.homes.icons.HomeIcon;
 import fr.openmc.core.features.homes.icons.HomeIconRegistry;
 import fr.openmc.core.features.homes.models.Home;
+import fr.openmc.core.utils.bukkit.PlayerUtils;
 import fr.openmc.core.utils.text.messages.MessageType;
 import fr.openmc.core.utils.text.messages.MessagesManager;
 import fr.openmc.core.utils.text.messages.Prefix;
@@ -107,24 +108,25 @@ public class HomeMenu extends PaginatedMenu {
                 }).hide(ItemUtils.getDataComponentType()).setOnClick(event -> {
                     if(event.isLeftClick()) {
                         this.getInventory().close();
-                        getOwner().teleportAsync(home.getLocation()).thenAccept(success -> {
-                            new BukkitRunnable() {
-                                @Override
-                                public void run() {
-                                    Bukkit.getPluginManager().callEvent(new HomeTpEvent(home, getOwner()));
-                                }
-                            }.runTask(OMCPlugin.getInstance());
-                            MessagesManager.sendMessage(
-                                    getOwner(),
-                                    TranslationManager.translation(
-                                            "feature.homes.menu.teleport.success",
-                                            Component.text(home.getName()).color(NamedTextColor.YELLOW)
-                                    ),
-                                    Prefix.HOME,
-                                    MessageType.SUCCESS,
-                                    true
-                            );
-                        });
+                        if (!PlayerUtils.sendFadeTitleTeleport(getOwner(), home.getLocation())) {
+                            return;
+                        }
+                        new BukkitRunnable() {
+                            @Override
+                            public void run() {
+                                Bukkit.getPluginManager().callEvent(new HomeTpEvent(home, getOwner()));
+                            }
+                        }.runTask(OMCPlugin.getInstance());
+                        MessagesManager.sendMessage(
+                                getOwner(),
+                                TranslationManager.translation(
+                                        "feature.homes.menu.teleport.success",
+                                        Component.text(home.getName()).color(NamedTextColor.YELLOW)
+                                ),
+                                Prefix.HOME,
+                                MessageType.SUCCESS,
+                                true
+                        );
                     } else if(event.isRightClick()) {
                         Player player = (Player) event.getWhoClicked();
                         new HomeConfigMenu(player, home).open();

--- a/src/main/java/fr/openmc/core/features/tpa/commands/TPAcceptCommand.java
+++ b/src/main/java/fr/openmc/core/features/tpa/commands/TPAcceptCommand.java
@@ -20,62 +20,113 @@ import revxrsal.commands.bukkit.annotation.CommandPermission;
 import java.util.Objects;
 
 public class TPAcceptCommand {
-	
-	/**
-	 * Accept a teleportation request from another player.
-	 *
-	 * @param target The player who accepts the teleportation request.
-	 * @param player The player who sent the teleportation request (optional).
-	 */
-	@Command("tpaccept")
-	@CommandPermission("omc.commands.tpa")
-	public void tpAccept(
-			Player target,
-			@Optional @SuggestWith(TpaPendingAutoComplete.class) @Named("player") Player player
-	) {
-		if (!TPAManager.hasPendingRequest(target)) {
-			MessagesManager.sendMessage(target, TranslationManager.translation("feature.tpa.accept.no_pending"), Prefix.OPENMC, MessageType.ERROR, false);
-			return;
-		}
-		
-		if (TPAManager.hasMultipleRequests(target)) {
-			if (player == null) {
-				MessagesManager.sendMessage(target, TranslationManager.translation("feature.tpa.accept.multiple_requests"), Prefix.OPENMC, MessageType.ERROR, false);
-				return;
-			}
-			
-			if (!TPAManager.getRequesters(target).contains(player)) {
-				MessagesManager.sendMessage(target, TranslationManager.translation(
-						"feature.tpa.accept.no_request_from",
-						Component.text(player.getName()).color(NamedTextColor.GOLD)
-				), Prefix.OPENMC, MessageType.ERROR, false);
-				return;
-			}
-		} else {
-			player = TPAManager.getRequesters(target).getFirst();
-		}
-		
-		if (target.getFallDistance() > 0) {
-			MessagesManager.sendMessage(target, TranslationManager.translation("feature.tpa.accept.falling"), Prefix.OPENMC, MessageType.ERROR, true);
-			MessagesManager.sendMessage(player, TranslationManager.translation("feature.tpa.accept.you_falling"), Prefix.OPENMC, MessageType.ERROR, true);
-			return;
-		}
-		
-		if (!player.isOnline()) {
-			MessagesManager.sendMessage(target, TranslationManager.translation("feature.tpa.accept.player_not_online"), Prefix.OPENMC, MessageType.ERROR, true);
-			return;
-		}
-		
-		if (TPAManager.getTargetByRequester(player) != null) {
-			if (Objects.equals(TPAManager.getTargetByRequester(player), target)) teleport(player, target);
-		}
-	}
-	
-	private void teleport(Player requester, Player target) {
-		Location loc = target.getLocation();
-		PlayerUtils.sendFadeTitleTeleport(requester, loc);
-		MessagesManager.sendMessage(target, TranslationManager.translation("feature.tpa.accept.success"), Prefix.OPENMC, MessageType.SUCCESS, true);
-		MessagesManager.sendMessage(requester, TranslationManager.translation("feature.tpa.accept.success"), Prefix.OPENMC, MessageType.SUCCESS, true);
-		TPAManager.removeRequest(requester, target);
-	}
+
+    /**
+     * Accept a teleportation request from another player.
+     *
+     * @param target The player who accepts the teleportation request.
+     * @param player The player who sent the teleportation request (optional).
+     */
+    @Command("tpaccept")
+    @CommandPermission("omc.commands.tpa")
+    public void tpAccept(
+            Player target,
+            @Optional @SuggestWith(TpaPendingAutoComplete.class) @Named("player") Player player
+    ) {
+        if (!TPAManager.hasPendingRequest(target)) {
+            MessagesManager.sendMessage(
+                    target,
+                    TranslationManager.translation("feature.tpa.accept.no_pending"),
+                    Prefix.OPENMC,
+                    MessageType.ERROR,
+                    false
+            );
+            return;
+        }
+
+        if (TPAManager.hasMultipleRequests(target)) {
+            if (player == null) {
+                MessagesManager.sendMessage(
+                        target,
+                        TranslationManager.translation("feature.tpa.accept.multiple_requests"),
+                        Prefix.OPENMC,
+                        MessageType.ERROR,
+                        false
+                );
+                return;
+            }
+
+            if (!TPAManager.getRequesters(target).contains(player)) {
+                MessagesManager.sendMessage(
+                        target,
+                        TranslationManager.translation(
+                                "feature.tpa.accept.no_request_from",
+                                Component.text(player.getName()).color(NamedTextColor.GOLD)
+                        ),
+                        Prefix.OPENMC,
+                        MessageType.ERROR,
+                        false
+                );
+                return;
+            }
+        } else {
+            player = TPAManager.getRequesters(target).getFirst();
+        }
+
+        if (target.getFallDistance() > 0) {
+            MessagesManager.sendMessage(
+                    target,
+                    TranslationManager.translation("feature.tpa.accept.falling"),
+                    Prefix.OPENMC,
+                    MessageType.ERROR,
+                    true
+            );
+            MessagesManager.sendMessage(
+                    player,
+                    TranslationManager.translation("feature.tpa.accept.you_falling"),
+                    Prefix.OPENMC,
+                    MessageType.ERROR,
+                    true
+            );
+            return;
+        }
+
+        if (!player.isOnline()) {
+            MessagesManager.sendMessage(
+                    target,
+                    TranslationManager.translation("feature.tpa.accept.player_not_online"),
+                    Prefix.OPENMC,
+                    MessageType.ERROR,
+                    true
+            );
+            return;
+        }
+
+        if (Objects.equals(TPAManager.getTargetByRequester(player), target)) {
+            teleport(player, target);
+        }
+    }
+
+    private void teleport(Player requester, Player target) {
+        Location location = target.getLocation();
+        if (!PlayerUtils.sendFadeTitleTeleport(requester, location)) {
+            return;
+        }
+
+        MessagesManager.sendMessage(
+                target,
+                TranslationManager.translation("feature.tpa.accept.success"),
+                Prefix.OPENMC,
+                MessageType.SUCCESS,
+                true
+        );
+        MessagesManager.sendMessage(
+                requester,
+                TranslationManager.translation("feature.tpa.accept.success"),
+                Prefix.OPENMC,
+                MessageType.SUCCESS,
+                true
+        );
+        TPAManager.removeRequest(requester, target);
+    }
 }

--- a/src/main/java/fr/openmc/core/utils/bukkit/PlayerUtils.java
+++ b/src/main/java/fr/openmc/core/utils/bukkit/PlayerUtils.java
@@ -2,10 +2,15 @@ package fr.openmc.core.utils.bukkit;
 
 import dev.lone.itemsadder.api.FontImages.FontImageWrapper;
 import fr.openmc.core.OMCPlugin;
+import fr.openmc.core.features.combat.CombatCooldownManager;
 import fr.openmc.core.features.settings.PlayerSettingsManager;
 import fr.openmc.core.features.settings.SettingType;
+import fr.openmc.core.utils.text.messages.MessageType;
+import fr.openmc.core.utils.text.messages.MessagesManager;
+import fr.openmc.core.utils.text.messages.Prefix;
 import fr.openmc.core.utils.text.messages.TranslationManager;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
 import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
@@ -20,41 +25,77 @@ import java.time.Duration;
 import java.util.List;
 
 public class PlayerUtils {
-	public static void sendFadeTitleTeleport(Player player, Location location) {
-		if (PlayerSettingsManager.getPlayerSettings(player.getUniqueId()).getSetting(SettingType.TELEPORT_TITLE_FADE)) {
+
+    private static final long TELEPORT_DELAY_TICKS = 14L;
+
+    public static boolean sendFadeTitleTeleport(Player player, Location location) {
+        if (!canTeleport(player)) {
+            return false;
+        }
+
+        if (PlayerSettingsManager.getPlayerSettings(player.getUniqueId())
+                .getSetting(SettingType.TELEPORT_TITLE_FADE)) {
             player.showTitle(Title.title(
                     Component.text(FontImageWrapper.replaceFontImages(":tp_effect:")),
-					TranslationManager.translation("core.utils.fade_title.teleporting"),
-                    Title.Times.times(Duration.ofMillis(20 * 50), Duration.ofMillis(10 * 50), Duration.ofMillis(10 * 50))
+                    TranslationManager.translation("core.utils.fade_title.teleporting"),
+                    Title.Times.times(
+                            Duration.ofMillis(1000),
+                            Duration.ofMillis(500),
+                            Duration.ofMillis(500)
+                    )
             ));
-			new BukkitRunnable() {
-				@Override
-				public void run() {
-					player.teleport(location);
-				}
-			}.runTaskLater(OMCPlugin.getInstance(), 14);
-		} else {
-			player.teleportAsync(location);
-		}
-	}
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    if (canTeleport(player)) {
+                        player.teleport(location);
+                    }
+                }
+            }.runTaskLater(OMCPlugin.getInstance(), TELEPORT_DELAY_TICKS);
+        } else {
+            player.teleportAsync(location);
+        }
 
-	/**
-	 * Fait apparaitre l'effet de gel sur le joueur
-	 *
-	 * @param player      joueur a donné l'effet
-	 * @param freezeTicks nombre de ticks de gel (de 0 à 140)
-	 */
-	public static void showFreezeEffect(Player player, int freezeTicks) {
-		EntityDataAccessor<Integer> FREEZE_TICKS = new EntityDataAccessor<>(7, EntityDataSerializers.INT);
+        return true;
+    }
 
-		SynchedEntityData.DataValue<Integer> dataValue =
-				new SynchedEntityData.DataValue<>(7, FREEZE_TICKS.serializer(), freezeTicks);
+    private static boolean canTeleport(Player player) {
+        long remainingSeconds = CombatCooldownManager.getRemainingSeconds(player.getUniqueId());
+        if (remainingSeconds == 0) {
+            return true;
+        }
 
-		List<SynchedEntityData.DataValue<?>> dataList = List.of(dataValue);
+        MessagesManager.sendMessage(
+                player,
+                TranslationManager.translation(
+                        "core.utils.teleport.combat_cooldown",
+                        Component.text(remainingSeconds).color(NamedTextColor.YELLOW)
+                ),
+                Prefix.OPENMC,
+                MessageType.ERROR,
+                true
+        );
+        return false;
+    }
 
-		ClientboundSetEntityDataPacket packet =
-				new ClientboundSetEntityDataPacket(player.getEntityId(), dataList);
+    /**
+     * Fait apparaitre l'effet de gel sur le joueur
+     *
+     * @param player      joueur a donné l'effet
+     * @param freezeTicks nombre de ticks de gel (de 0 à 140)
+     */
+    public static void showFreezeEffect(Player player, int freezeTicks) {
+        EntityDataAccessor<Integer> freezeTicksAccessor =
+                new EntityDataAccessor<>(7, EntityDataSerializers.INT);
 
-		((CraftPlayer) player).getHandle().connection.send(packet);
-	}
+        SynchedEntityData.DataValue<Integer> dataValue =
+                new SynchedEntityData.DataValue<>(7, freezeTicksAccessor.serializer(), freezeTicks);
+
+        List<SynchedEntityData.DataValue<?>> dataList = List.of(dataValue);
+
+        ClientboundSetEntityDataPacket packet =
+                new ClientboundSetEntityDataPacket(player.getEntityId(), dataList);
+
+        ((CraftPlayer) player).getHandle().connection.send(packet);
+    }
 }

--- a/src/main/resources/translations/default/utils.properties
+++ b/src/main/resources/translations/default/utils.properties
@@ -1,3 +1,4 @@
 core.utils.fade_title.teleporting=<bold><green>Téléportation...</green></bold>
+core.utils.teleport.combat_cooldown=<red>Vous êtes en combat, vous pourrez vous téléporter dans </red>%1$s<red> seconde(s).</red>
 core.utils.aywenite.not_enough=Vous n'avez pas assez d'%1$s <white>(%2$s nécessaires)</white>
 core.utils.aywenite.not_enough_space=Vous n'avez pas assez de place dans votre inventaire pour recevoir %1$s d'%2$s<white>. L'aywenite est disponible dans votre mailbox</white>


### PR DESCRIPTION
## Petit résumé de la PR
Ajout d'un cooldown de combat qui bloque les téléportations tant que le joueur est encore en combat, et ajout d'une task Gradle unDevServer pour lancer un serveur Paper local avec le plugin compilé.

## Ce que ça rajoute
- Blocage des téléportations via /spawn, /home, /city warp et /tpa pendant le cooldown de combat.
- Message de feedback quand le joueur essaie de se téléporter pendant le combat.
- Enregistrement du listener de combat dans le gestionnaire des listeners.
- Task unDevServer pour lancer un serveur Paper local et copier le jar du plugin dans un/plugins.
- Mise à jour des textes de traduction pour le message de cooldown.

## Issue liée
- Closes #1035

## Validation avant merge
- [ ] Suivre le Code de Conduite
- [ ] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tous les checks
- [ ] Tester et valider la feature/changement

## Notes de test
- ./gradlew test compile, mais la suite contient des échecs existants hors périmètre de cette PR.