### PR TITLE
[CHANGE] Refonte des hologrammes Paper

### DIFF
--- a/src/main/java/fr/openmc/api/scoreboard/SternalBoard.java
+++ b/src/main/java/fr/openmc/api/scoreboard/SternalBoard.java
@@ -120,7 +120,7 @@ public class SternalBoard extends SternalBoardHandler<Component> {
         Component line = getLineByScore(score);
 
         if (line == null || line.equals(Component.empty())) {
-            Component emptyPrefix = Component.text(COLOR_CODES[score], NamedTextColor.WHITE);
+            Component emptyPrefix = LEGACY_SERIALIZER.deserialize(COLOR_CODES[score]).color(NamedTextColor.WHITE);
             sendTeamPacket(score, TeamMode.UPDATE, emptyPrefix, Component.empty());
             return;
         }

--- a/src/main/java/fr/openmc/core/features/displays/TabList.java
+++ b/src/main/java/fr/openmc/core/features/displays/TabList.java
@@ -19,6 +19,7 @@ import fr.openmc.core.hooks.itemsadder.ItemsAdderHook;
 import fr.openmc.core.utils.text.messages.TranslationManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -103,13 +104,13 @@ public class TabList extends Feature implements NotInUnitTest, LoadIfEnable<Prot
         String header = !isInDream
                 ? TranslationManager.translationString(
                         "feature.displays.tablist.header.default",
-                        Component.text(logo),
+                        LegacyComponentSerializer.legacySection().deserialize(logo),
                         Component.text(visibleOnlinePlayers).color(NamedTextColor.GOLD),
                         Component.text(Bukkit.getMaxPlayers()).color(NamedTextColor.YELLOW)
                 )
                 : TranslationManager.translationString(
                         "feature.displays.tablist.header.dream",
-                        Component.text(logo)
+                        LegacyComponentSerializer.legacySection().deserialize(logo)
                 );
         String footer = isInDream
                 ? TranslationManager.translationString("feature.displays.tablist.footer.dream")

--- a/src/main/java/fr/openmc/core/features/displays/holograms/HologramLoader.java
+++ b/src/main/java/fr/openmc/core/features/displays/holograms/HologramLoader.java
@@ -15,6 +15,8 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 import org.joml.Vector3f;
 
 import java.io.File;
@@ -26,6 +28,7 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
 
     private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
     public static final HashMap<String, HologramInfo> displays = new HashMap<>();
+    private static BukkitTask taskTimer;
     public static File hologramFolder;
 
     public static File getHologramFolder() {
@@ -48,6 +51,7 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
                 new TutorialHologram()
         );
 
+        updateHologramsViewers();
         HologramLoader.loadAllFromFolder(hologramFolder);
     }
 
@@ -61,6 +65,15 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
     @Override
     public void save() {
         HologramLoader.unloadAll();
+    }
+
+    public static void updateHologramsViewers() {
+        taskTimer = new BukkitRunnable() {
+            @Override
+            public void run() {
+                displays.values().forEach(hologramInfo -> hologramInfo.display().updateViewersList());
+            }
+        }.runTaskTimerAsynchronously(OMCPlugin.getInstance(), 0, 20L);
     }
 
     public static void registerHolograms(Hologram... holograms) {
@@ -139,6 +152,7 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
         for (HologramInfo info : displays.values()) {
             info.display().remove();
         }
+        taskTimer.cancel();
         displays.clear();
     }
 

--- a/src/main/java/fr/openmc/core/features/displays/holograms/HologramLoader.java
+++ b/src/main/java/fr/openmc/core/features/displays/holograms/HologramLoader.java
@@ -11,6 +11,7 @@ import fr.openmc.core.features.displays.holograms.commands.HologramCommand;
 import fr.openmc.core.features.milestones.tutorial.TutorialHologram;
 import fr.openmc.core.utils.world.entities.TextDisplay;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -23,6 +24,7 @@ import java.util.*;
 @Credit(developers = {"iambibi_", "miseur"})
 public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterItemsAdder, HasCommands {
 
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
     public static final HashMap<String, HologramInfo> displays = new HashMap<>();
     public static File hologramFolder;
 
@@ -85,9 +87,9 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
                 String rawLine = hologram.getLines()[i];
 
                 if (component == null) {
-                    component = Component.text(rawLine);
+                    component = LEGACY_SERIALIZER.deserialize(rawLine);
                 } else {
-                    component = component.append(Component.newline()).append(Component.text(rawLine));
+                    component = component.append(Component.newline()).append(LEGACY_SERIALIZER.deserialize(rawLine));
                 }
             }
 
@@ -124,9 +126,9 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
         for (int i = 0; i < lines.size(); i++) {
             String rawLine = lines.get(i);
             if (component == null) {
-                component = Component.text(rawLine);
+                component = LEGACY_SERIALIZER.deserialize(rawLine);
             } else {
-                component = component.append(Component.newline()).append(Component.text(rawLine));
+                component = component.append(Component.newline()).append(LEGACY_SERIALIZER.deserialize(rawLine));
             }
         }
         TextDisplay display = new TextDisplay(component, hologramLocation, new Vector3f(scale));

--- a/src/main/java/fr/openmc/core/features/displays/holograms/HologramLoader.java
+++ b/src/main/java/fr/openmc/core/features/displays/holograms/HologramLoader.java
@@ -14,8 +14,6 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitTask;
 import org.joml.Vector3f;
 
 import java.io.File;
@@ -26,7 +24,6 @@ import java.util.*;
 public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterItemsAdder, HasCommands {
 
     public static final HashMap<String, HologramInfo> displays = new HashMap<>();
-    private static BukkitTask taskTimer;
     public static File hologramFolder;
 
     public static File getHologramFolder() {
@@ -49,7 +46,6 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
                 new TutorialHologram()
         );
 
-        updateHologramsViewers();
         HologramLoader.loadAllFromFolder(hologramFolder);
     }
 
@@ -63,18 +59,6 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
     @Override
     public void save() {
         HologramLoader.unloadAll();
-    }
-
-    public static void updateHologramsViewers() {
-        taskTimer = new BukkitRunnable() {
-            @Override
-            public void run() {
-                displays.values().forEach(hologramInfo -> {
-                    TextDisplay display = hologramInfo.display();
-                    display.updateViewersList();
-                });
-            }
-        }.runTaskTimerAsynchronously(OMCPlugin.getInstance(), 0, 20L); // Toutes les 15 secondes en async sauf l'updateGithubContributorsMap qui est toutes les 30 minutes
     }
 
     public static void registerHolograms(Hologram... holograms) {
@@ -153,7 +137,6 @@ public class HologramLoader extends Feature implements NotInUnitTest, LoadAfterI
         for (HologramInfo info : displays.values()) {
             info.display().remove();
         }
-        taskTimer.cancel();
         displays.clear();
     }
 

--- a/src/main/java/fr/openmc/core/features/displays/holograms/commands/HologramCommand.java
+++ b/src/main/java/fr/openmc/core/features/displays/holograms/commands/HologramCommand.java
@@ -81,7 +81,6 @@ public class HologramCommand {
     @CommandPermission("op")
     @Description("Active tout")
     void enableCommand(CommandSender sender) {
-        HologramLoader.updateHologramsViewers();
         HologramLoader.loadAllFromFolder(hologramFolder);
         MessagesManager.sendMessage(
                 sender,

--- a/src/main/java/fr/openmc/core/features/displays/scoreboards/BaseScoreboard.java
+++ b/src/main/java/fr/openmc/core/features/displays/scoreboards/BaseScoreboard.java
@@ -7,12 +7,14 @@ import fr.openmc.core.utils.text.messages.TranslationManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.entity.Player;
 
 import static fr.openmc.core.utils.text.messages.MessagesManager.textToSmall;
 
 public abstract class BaseScoreboard {
     protected static final boolean canShowLogo = ItemsAdderHook.isEnable();
+    protected static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
 
     /**
      * Initialise le scoreboard pour un joueur
@@ -66,7 +68,7 @@ public abstract class BaseScoreboard {
      */
     public Component getTitle() {
         return canShowLogo
-                ? Component.text(FontImageWrapper.replaceFontImages(":openmc:"))
+                ? LEGACY_SERIALIZER.deserialize(FontImageWrapper.replaceFontImages(":openmc:"))
                 : TranslationManager.translation("feature.displays.scoreboard.title.text").color(NamedTextColor.LIGHT_PURPLE);
     }
 

--- a/src/main/java/fr/openmc/core/features/displays/scoreboards/sb/MainScoreboard.java
+++ b/src/main/java/fr/openmc/core/features/displays/scoreboards/sb/MainScoreboard.java
@@ -72,7 +72,7 @@ public class MainScoreboard extends BaseScoreboard {
 
     public static List<Component> getDefaultLines(Player player) {
         Component rank = LuckPermsHook.isEnable()
-                ? Component.text(LuckPermsHook.getFormattedPAPIPrefix(player))
+                ? LEGACY_SERIALIZER.deserialize(LuckPermsHook.getFormattedPAPIPrefix(player))
                 : Component.text(keyToSmall("feature.displays.scoreboard.rank.none")).color(TextColor.color(0xFF1FCC));
 
 
@@ -98,19 +98,22 @@ public class MainScoreboard extends BaseScoreboard {
         lines.add(text("  • ", NamedTextColor.DARK_GRAY)
                 .append(text(keyToSmall("feature.displays.scoreboard.city.label"), NamedTextColor.GRAY))
                 .appendSpace()
-                .append(text(textToSmall(city != null ? city.getName() : TranslationManager.translationString("feature.displays.scoreboard.city.none"))).color(TextColor.color(0xFF06DC)))
+                .append(LEGACY_SERIALIZER.deserialize(textToSmall(city != null
+                        ? city.getName()
+                        : TranslationManager.translationString("feature.displays.scoreboard.city.none")))
+                        .color(TextColor.color(0xFF06DC)))
         );
         lines.add(text("  • ", NamedTextColor.DARK_GRAY)
                 .append(text(keyToSmall("feature.displays.scoreboard.balance.label"), NamedTextColor.GRAY))
                 .appendSpace()
                 .append(text(textToSmall(balance)).color(TextColor.color(0xFF06DC)))
                 .appendSpace()
-                .append(text(EconomyManager.getEconomyIcon()))
+                .append(LEGACY_SERIALIZER.deserialize(EconomyManager.getEconomyIcon()))
         );
         lines.add(text("  • ", NamedTextColor.DARK_GRAY)
                 .append(text(keyToSmall("feature.displays.scoreboard.location.label"), NamedTextColor.GRAY))
                 .appendSpace()
-                .append(text(textToSmall(location)).color(TextColor.color(0xFF06DC)))
+                .append(LEGACY_SERIALIZER.deserialize(textToSmall(location)).color(TextColor.color(0xFF06DC)))
         );
 
         if (FancyNpcsHook.isEnable()) {

--- a/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
+++ b/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
@@ -25,6 +25,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
@@ -169,7 +170,9 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
             Component rankComponent = Component.text("#")
                     .color(rankColor)
                     .append(Component.text(rank).color(rankColor));
-            Component valueComponent = Component.text(money + " " + EconomyManager.getEconomyIcon())
+            Component valueComponent = Component.text(money + " ")
+                    .append(LegacyComponentSerializer.legacySection()
+                            .deserialize(EconomyManager.getEconomyIcon()))
                     .color(NamedTextColor.WHITE);
             Component line = Component.text("\n")
                     .append(TranslationManager.translation(
@@ -212,7 +215,9 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
             Component rankComponent = Component.text("#")
                     .color(rankColor)
                     .append(Component.text(rank).color(rankColor));
-            Component valueComponent = Component.text(money + " " + EconomyManager.getEconomyIcon())
+            Component valueComponent = Component.text(money + " ")
+                    .append(LegacyComponentSerializer.legacySection()
+                            .deserialize(EconomyManager.getEconomyIcon()))
                     .color(NamedTextColor.WHITE);
             Component line = Component.text("\n")
                     .append(TranslationManager.translation(

--- a/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
+++ b/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
@@ -342,28 +342,9 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
                     updatePumpkinCountMap();
                     updateHolograms();
                 }
-                updateHologramsViewers();
                 i++;
             }
         }.runTaskTimerAsynchronously(OMCPlugin.getInstance(), 0, 20L); // Toutes les 15 secondes en async sauf l'updateGithubContributorsMap qui est toutes les 30 minutes
-    }
-
-    public static void updateHologramsViewers() {
-        if (contributorsHologramLocation != null) {
-            contributorsHologram.updateViewersList();
-        }
-        if (moneyHologramLocation != null) {
-            moneyHologram.updateViewersList();
-        }
-        if (villeMoneyHologramLocation != null) {
-            villeMoneyHologram.updateViewersList();
-        }
-        if (playTimeHologramLocation != null) {
-            playTimeHologram.updateViewersList();
-        }
-        if (pumpkinCountHologramLocation != null) {
-            pumpkinCountHologram.updateViewersList();
-        }
     }
 
     public static void disable() {
@@ -618,20 +599,14 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
      * Updates the holograms for all leaderboards by sending ENTITY_METADATA packets to players.
      */
     public static void updateHolograms() {
-        if (contributorsHologram != null) {
-            contributorsHologram.updateText(createContributorsTextLeaderboard());
-        }
-        if (moneyHologram != null) {
-            moneyHologram.updateText(createMoneyTextLeaderboard());
-        }
-        if (villeMoneyHologram != null) {
-            villeMoneyHologram.updateText(createCityMoneyTextLeaderboard());
-        }
-        if (playTimeHologram != null) {
-            playTimeHologram.updateText(createPlayTimeTextLeaderboard());
-        }
-        if (pumpkinCountHologram != null) {
-            pumpkinCountHologram.updateText(createPumpkinCountTextLeaderboard());
-        }
+        update(contributorsHologram, createContributorsTextLeaderboard());
+        update(moneyHologram, createMoneyTextLeaderboard());
+        update(villeMoneyHologram, createCityMoneyTextLeaderboard());
+        update(playTimeHologram, createPlayTimeTextLeaderboard());
+        update(pumpkinCountHologram, createPumpkinCountTextLeaderboard());
+    }
+
+    private static void update(TextDisplay hologram, Component text) {
+        if (hologram != null) hologram.updateText(text);
     }
 }

--- a/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
+++ b/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
@@ -347,9 +347,28 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
                     updatePumpkinCountMap();
                     updateHolograms();
                 }
+                updateHologramsViewers();
                 i++;
             }
         }.runTaskTimerAsynchronously(OMCPlugin.getInstance(), 0, 20L); // Toutes les 15 secondes en async sauf l'updateGithubContributorsMap qui est toutes les 30 minutes
+    }
+
+    public static void updateHologramsViewers() {
+        if (contributorsHologramLocation != null) {
+            contributorsHologram.updateViewersList();
+        }
+        if (moneyHologramLocation != null) {
+            moneyHologram.updateViewersList();
+        }
+        if (villeMoneyHologramLocation != null) {
+            villeMoneyHologram.updateViewersList();
+        }
+        if (playTimeHologramLocation != null) {
+            playTimeHologram.updateViewersList();
+        }
+        if (pumpkinCountHologramLocation != null) {
+            pumpkinCountHologram.updateViewersList();
+        }
     }
 
     public static void disable() {

--- a/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
+++ b/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
@@ -49,15 +49,15 @@ import java.util.*;
 @Credit(developers = {"miseur"})
 public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAfterItemsAdder, HasCommands {
     @Getter
-    private static final Map<Integer, Map.Entry<String, ContributorStats>> githubContributorsMap = new TreeMap<>();
+    private static volatile Map<Integer, Map.Entry<String, ContributorStats>> githubContributorsMap = new TreeMap<>();
     @Getter
-    private static final Map<Integer, Map.Entry<String, String>> playerMoneyMap = new TreeMap<>();
+    private static volatile Map<Integer, Map.Entry<String, String>> playerMoneyMap = new TreeMap<>();
     @Getter
-    private static final Map<Integer, Map.Entry<String, String>> villeMoneyMap = new TreeMap<>();
+    private static volatile Map<Integer, Map.Entry<String, String>> villeMoneyMap = new TreeMap<>();
     @Getter
-    private static final Map<Integer, Map.Entry<String, String>> playTimeMap = new TreeMap<>();
+    private static volatile Map<Integer, Map.Entry<String, String>> playTimeMap = new TreeMap<>();
     @Getter
-    private static final Map<Integer, Map.Entry<String, String>> pumpkinCountMap = new TreeMap<>();
+    private static volatile Map<Integer, Map.Entry<String, String>> pumpkinCountMap = new TreeMap<>();
     private static File leaderBoardFile;
     @Getter
     private static Location contributorsHologramLocation;
@@ -518,11 +518,12 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
                         Integer.compare(e2.getValue().getTotalLines(), e1.getValue().getTotalLines())
                 );
 
-                githubContributorsMap.clear();
+                Map<Integer, Map.Entry<String, ContributorStats>> updatedContributors = new TreeMap<>();
 
                 for (int i = 0; i < Math.min(10, statsList.size()); i++) {
-                    githubContributorsMap.put(i + 1, statsList.get(i));
+                    updatedContributors.put(i + 1, statsList.get(i));
                 }
+                githubContributorsMap = updatedContributors;
             }
             con.disconnect();
         } catch (Exception e) {
@@ -534,7 +535,7 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
      * Updates the player money leaderboard map by sorting and formatting player balances.
      */
     public static void updatePlayerMoneyMap() {
-        playerMoneyMap.clear();
+        Map<Integer, Map.Entry<String, String>> updatedMoney = new TreeMap<>();
         int rank = 1;
 
         Map<UUID, EconomyPlayer> balances = EconomyManager.getBalances();
@@ -549,15 +550,16 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
                 .toList()) {
             String playerName = PlayerNameCache.getName(entry.getKey());
             String formattedBalance = EconomyManager.getFormattedSimplifiedNumber(entry.getValue());
-            playerMoneyMap.put(rank++, new AbstractMap.SimpleEntry<>(playerName, formattedBalance));
+            updatedMoney.put(rank++, new AbstractMap.SimpleEntry<>(playerName, formattedBalance));
         }
+        playerMoneyMap = updatedMoney;
     }
 
     /**
      * Updates the city money leaderboard map by sorting and formatting city balances.
      */
     public static void updateCityMoneyMap() {
-        villeMoneyMap.clear();
+        Map<Integer, Map.Entry<String, String>> updatedCityMoney = new TreeMap<>();
         int rank = 1;
         for (City city : CityManager.getCities().stream()
                 .sorted((city1, city2) -> Double.compare(city2.getBalance(), city1.getBalance()))
@@ -565,15 +567,16 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
                 .toList()) {
             String cityName = city.getName();
             String cityBalance = EconomyManager.getFormattedSimplifiedNumber(city.getBalance());
-            villeMoneyMap.put(rank++, new AbstractMap.SimpleEntry<>(cityName, cityBalance));
+            updatedCityMoney.put(rank++, new AbstractMap.SimpleEntry<>(cityName, cityBalance));
         }
+        villeMoneyMap = updatedCityMoney;
     }
 
     /**
      * Updates the playtime leaderboard map by sorting and formatting player playtime.
      */
     public static void updatePlayTimeMap() {
-        playTimeMap.clear();
+        Map<Integer, Map.Entry<String, String>> updatedPlayTime = new TreeMap<>();
         int rank = 1;
         for (OfflinePlayer player : Arrays.stream(Bukkit.getOfflinePlayers())
                 .sorted((entry1, entry2) -> Long.compare(entry2.getStatistic(Statistic.PLAY_ONE_MINUTE), entry1.getStatistic(Statistic.PLAY_ONE_MINUTE)))
@@ -581,12 +584,13 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
                 .toList()) {
             String playerName = player.getName();
             String playTime = DateUtils.convertTime(player.getStatistic(Statistic.PLAY_ONE_MINUTE));
-            playTimeMap.put(rank++, new AbstractMap.SimpleEntry<>(playerName, playTime));
+            updatedPlayTime.put(rank++, new AbstractMap.SimpleEntry<>(playerName, playTime));
         }
+        playTimeMap = updatedPlayTime;
     }
 
     public static void updatePumpkinCountMap() {
-        pumpkinCountMap.clear();
+        Map<Integer, Map.Entry<String, String>> updatedPumpkinCount = new TreeMap<>();
         int rank = 1;
 
         Object2ObjectMap<UUID, HalloweenData> balances = HalloweenManager.getAllHalloweenData();
@@ -596,8 +600,9 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
                 .toList()) {
             String playerName = PlayerNameCache.getName(entry.getKey());
             String formattedPumpkinCount = EconomyManager.getFormattedSimplifiedNumber(entry.getValue().getPumpkinCount());
-            pumpkinCountMap.put(rank++, new AbstractMap.SimpleEntry<>(playerName, formattedPumpkinCount));
+            updatedPumpkinCount.put(rank++, new AbstractMap.SimpleEntry<>(playerName, formattedPumpkinCount));
         }
+        pumpkinCountMap = updatedPumpkinCount;
     }
 
     /**

--- a/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
+++ b/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
@@ -196,7 +196,7 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
      * @return A Component representing the playtime leaderboard.
      */
     public static Component createCityMoneyTextLeaderboard() {
-        var moneyMap = LeaderboardManager.getVilleMoneyMap();
+        var moneyMap = new TreeMap<>(LeaderboardManager.getVilleMoneyMap());
         if (moneyMap.isEmpty()) {
             return TranslationManager.translation("feature.leaderboards.empty.cities")
                     .color(NamedTextColor.RED);

--- a/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
+++ b/src/main/java/fr/openmc/core/features/leaderboards/LeaderboardManager.java
@@ -361,6 +361,11 @@ public class LeaderboardManager extends Feature implements NotInUnitTest, LoadAf
         pumpkinCountHologram.remove();
     }
 
+    @Override
+    protected void save() {
+        disable();
+    }
+
     /**
      * Sets the location of a hologram in the leaderboard configuration.
      *

--- a/src/main/java/fr/openmc/core/features/leaderboards/commands/LeaderboardCommands.java
+++ b/src/main/java/fr/openmc/core/features/leaderboards/commands/LeaderboardCommands.java
@@ -137,7 +137,6 @@ public class LeaderboardCommands {
         LeaderboardManager.updatePlayTimeMap();
         LeaderboardManager.updatePumpkinCountMap();
         LeaderboardManager.updateHolograms();
-        LeaderboardManager.updateHologramsViewers();
         sender.sendMessage(TranslationManager.translation("feature.leaderboards.command.holograms_updated")
                 .color(NamedTextColor.GREEN));
     }

--- a/src/main/java/fr/openmc/core/features/milestones/tutorial/TutorialHologram.java
+++ b/src/main/java/fr/openmc/core/features/milestones/tutorial/TutorialHologram.java
@@ -3,8 +3,8 @@ package fr.openmc.core.features.milestones.tutorial;
 import fr.openmc.core.features.displays.holograms.Hologram;
 import fr.openmc.core.utils.text.fonts.CustomFonts;
 import fr.openmc.core.utils.text.messages.TranslationManager;
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 public class TutorialHologram extends Hologram {
 
@@ -15,7 +15,7 @@ public class TutorialHologram extends Hologram {
         this.setLines(
                 TranslationManager.translationString(
                         "feature.milestones.tutorial.hologram.icon",
-                        Component.text(icon).color(NamedTextColor.WHITE)
+                        LegacyComponentSerializer.legacySection().deserialize(icon).color(NamedTextColor.WHITE)
                 ),
                 TranslationManager.translationString("feature.milestones.tutorial.hologram.welcome"),
                 TranslationManager.translationString("feature.milestones.tutorial.hologram.based_on"),

--- a/src/main/java/fr/openmc/core/listeners/JoinQuitMessageListener.java
+++ b/src/main/java/fr/openmc/core/listeners/JoinQuitMessageListener.java
@@ -17,6 +17,7 @@ import fr.openmc.core.utils.text.messages.TranslationManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -51,7 +52,9 @@ public class JoinQuitMessageListener implements Listener {
                  if (friend != null && friend.isOnline() && !friend.hasMetadata(OMCPlugin.VANISH_META_KEY)) {
                       MessagesManager.sendMessage(friend, TranslationManager.translation(
                               "core.player.join.friend_online",
-                              Component.text(LuckPermsHook.getFormattedPAPIPrefix(player) + player.getName()).color(NamedTextColor.GREEN)
+                              LegacyComponentSerializer.legacySection()
+                                      .deserialize(LuckPermsHook.getFormattedPAPIPrefix(player) + player.getName())
+                                      .color(NamedTextColor.GREEN)
                       ), Prefix.FRIEND, MessageType.NONE, true);
                  }
              }
@@ -81,7 +84,8 @@ public class JoinQuitMessageListener implements Listener {
          });
 
         if (!player.hasMetadata(OMCPlugin.VANISH_META_KEY))
-            event.joinMessage(Component.text(JOIN_MESSAGE.formatted(LuckPermsHook.getFormattedPAPIPrefix(player), player.getName())));
+            event.joinMessage(LegacyComponentSerializer.legacySection()
+                    .deserialize(JOIN_MESSAGE.formatted(LuckPermsHook.getFormattedPAPIPrefix(player), player.getName())));
 
         // Adjust player's spawn location
         if (!player.hasPlayedBefore()) {
@@ -114,7 +118,9 @@ public class JoinQuitMessageListener implements Listener {
                  if (friend != null && friend.isOnline() && !friend.hasMetadata(OMCPlugin.VANISH_META_KEY)) {
                      MessagesManager.sendMessage(friend, TranslationManager.translation(
                              "core.player.quit.friend_offline",
-                             Component.text(LuckPermsHook.getFormattedPAPIPrefix(player) + player.getName()).color(NamedTextColor.YELLOW)
+                             LegacyComponentSerializer.legacySection()
+                                     .deserialize(LuckPermsHook.getFormattedPAPIPrefix(player) + player.getName())
+                                     .color(NamedTextColor.YELLOW)
                      ), Prefix.FRIEND, MessageType.NONE, true);
                  }
              }
@@ -141,7 +147,8 @@ public class JoinQuitMessageListener implements Listener {
          }
 
         if (!player.hasMetadata(OMCPlugin.VANISH_META_KEY))
-            event.quitMessage(Component.text(QUIT_MESSAGE.formatted(LuckPermsHook.getFormattedPAPIPrefix(player), player.getName())));
+            event.quitMessage(LegacyComponentSerializer.legacySection()
+                    .deserialize(QUIT_MESSAGE.formatted(LuckPermsHook.getFormattedPAPIPrefix(player), player.getName())));
     }
 
 }

--- a/src/main/java/fr/openmc/core/utils/text/messages/MessagesManager.java
+++ b/src/main/java/fr/openmc/core/utils/text/messages/MessagesManager.java
@@ -2,6 +2,7 @@ package fr.openmc.core.utils.text.messages;
 
 import fr.openmc.core.features.settings.PlayerSettingsManager;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
@@ -13,6 +14,8 @@ import java.util.List;
 import java.util.Map;
 
 public class MessagesManager {
+
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
 
     /*
     For use the beautiful message, create a prefix.
@@ -40,9 +43,9 @@ public class MessagesManager {
      */
     public static void sendMessage(CommandSender sender, Component message, Prefix prefix, MessageType type, float soundVolume, boolean sound) {
         Component messageComponent =
-                Component.text(type == MessageType.NONE ? "" : "§7(" + type.getPrefix() + "§7) ")
+                LEGACY_SERIALIZER.deserialize(type == MessageType.NONE ? "" : "§7(" + type.getPrefix() + "§7) ")
                         .append(prefix.getPrefix())
-                        .append(Component.text(" §7» ")
+                        .append(LEGACY_SERIALIZER.deserialize(" §7» ")
                         .append(message)
                 );
 
@@ -104,9 +107,9 @@ public class MessagesManager {
      */
     public static void broadcastMessage(Component message, Prefix prefix, MessageType type) {
         Component messageComponent =
-                Component.text(type == MessageType.NONE ? "" : "§7(" + type.getPrefix() + "§7) ")
+                LEGACY_SERIALIZER.deserialize(type == MessageType.NONE ? "" : "§7(" + type.getPrefix() + "§7) ")
                         .append(prefix.getPrefix())
-                        .append(Component.text(" §7» ")
+                        .append(LEGACY_SERIALIZER.deserialize(" §7» ")
                         .append(message)
                 );
 

--- a/src/main/java/fr/openmc/core/utils/text/messages/TranslationManager.java
+++ b/src/main/java/fr/openmc/core/utils/text/messages/TranslationManager.java
@@ -116,7 +116,11 @@ public class TranslationManager {
      * @return Une chaîne au format legacy (codes §)
      */
     public static String translationString(String key, ComponentLike... args) {
-        return LEGACY_COMPONENT_SERIALIZER.serialize(translation(key, args));
+        Object[] legacyArgs = Arrays.stream(args)
+                .map(ComponentLike::asComponent)
+                .map(LEGACY_COMPONENT_SERIALIZER::serialize)
+                .toArray();
+        return String.format(getFallbackTranslation(key), legacyArgs);
     }
 
     /**

--- a/src/main/java/fr/openmc/core/utils/text/messages/TranslationManager.java
+++ b/src/main/java/fr/openmc/core/utils/text/messages/TranslationManager.java
@@ -10,9 +10,9 @@ import fr.openmc.core.utils.types.MultiResourceBundle;
 import io.papermc.paper.plugin.bootstrap.BootstrapContext;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,6 +32,7 @@ public class TranslationManager {
             .create();
 
     private static final LegacyComponentSerializer LEGACY_COMPONENT_SERIALIZER = LegacyComponentSerializer.legacySection();
+    private static final PlainTextComponentSerializer PLAIN_TEXT_SERIALIZER = PlainTextComponentSerializer.plainText();
 
     /**
      * Initialise le gestionnaire de traductions et génère les ressource packs.
@@ -98,7 +99,9 @@ public class TranslationManager {
      * @return Un composant Paper Adventure traduisible (italique désactivé)
      */
     public static Component translation(String key, ComponentLike... args) {
-        String fallback = getFallbackTranslation(key);
+        String fallback = PLAIN_TEXT_SERIALIZER.serialize(
+                LEGACY_COMPONENT_SERIALIZER.deserialize(getFallbackTranslation(key))
+        );
         ComponentLike[] normalizedArgs = ComponentUtils.normalizeComponent(args);
 
         return Component.translatable(
@@ -132,12 +135,7 @@ public class TranslationManager {
      * @return Une liste de composants, un par ligne (italique désactivé)
      */
     public static List<Component> translationLore(String key, ComponentLike... componentsArgs) {
-        String fallback = fallbackTranslations.getOrDefault(key, key);
-
-        ComponentLike[] normalizedArgs = ComponentUtils.normalizeComponent(componentsArgs);
-        TranslatableComponent translatable = Component.translatable(key, normalizedArgs).fallback(fallback);
-
-        String legacy = LegacyComponentSerializer.legacySection().serialize(translatable);
+        String legacy = translationString(key, componentsArgs);
 
         String[] lines = legacy.split("\n");
 

--- a/src/main/java/fr/openmc/core/utils/world/entities/TextDisplay.java
+++ b/src/main/java/fr/openmc/core/utils/world/entities/TextDisplay.java
@@ -12,19 +12,21 @@ import org.joml.Vector3f;
 public class TextDisplay {
 
     private org.bukkit.entity.TextDisplay entity;
+    private Location location;
 
     public TextDisplay(Component text, Location location, Vector3f scale) {
-        Location loc = at90(location);
-        sync(() -> entity = loc.getWorld().spawn(loc, org.bukkit.entity.TextDisplay.class, display -> {
-            display.text(text);
-            display.setBillboard(Display.Billboard.VERTICAL);
-            display.setBrightness(new Display.Brightness(15, 15));
-            display.setViewRange(2.0f);
-            display.setTransformation(new Transformation(new Vector3f(), new AxisAngle4f(), scale, new AxisAngle4f()));
-            //garder les chunks des holo chargés
-            //passer en persistant + tag PDC nettoyé au démarrage si un jour les holo sortent des spawn chunks
-            display.setPersistent(false);
-        }));
+        this.location = at90(location);
+        sync(() -> {
+            keepChunkLoaded(this.location);
+            entity = this.location.getWorld().spawn(this.location, org.bukkit.entity.TextDisplay.class, display -> {
+                display.text(text);
+                display.setBillboard(Display.Billboard.VERTICAL);
+                display.setBrightness(new Display.Brightness(15, 15));
+                display.setViewRange(2.0f);
+                display.setTransformation(new Transformation(new Vector3f(), new AxisAngle4f(), scale, new AxisAngle4f()));
+                display.setPersistent(false);
+            });
+        });
     }
 
     public void updateText(Component text) {
@@ -44,7 +46,13 @@ public class TextDisplay {
     public void setLocation(Location location) {
         Location loc = at90(location);
         sync(() -> {
-            if (entity != null) entity.teleport(loc);
+            if (entity == null) {
+                return;
+            }
+            releaseChunk(this.location);
+            this.location = loc;
+            keepChunkLoaded(this.location);
+            entity.teleport(this.location);
         });
     }
 
@@ -62,7 +70,16 @@ public class TextDisplay {
                 entity.remove();
                 entity = null;
             }
+            releaseChunk(location);
         });
+    }
+
+    private static void keepChunkLoaded(Location location) {
+        location.getWorld().addPluginChunkTicket(location.getChunk().getX(), location.getChunk().getZ(), OMCPlugin.getInstance());
+    }
+
+    private static void releaseChunk(Location location) {
+        location.getWorld().removePluginChunkTicket(location.getChunk().getX(), location.getChunk().getZ(), OMCPlugin.getInstance());
     }
 
     private static void sync(Runnable action) {

--- a/src/main/java/fr/openmc/core/utils/world/entities/TextDisplay.java
+++ b/src/main/java/fr/openmc/core/utils/world/entities/TextDisplay.java
@@ -1,89 +1,162 @@
 package fr.openmc.core.utils.world.entities;
 
-import fr.openmc.core.OMCPlugin;
+import com.mojang.math.Transformation;
+import io.papermc.paper.adventure.PaperAdventure;
 import net.kyori.adventure.text.Component;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Brightness;
+import net.minecraft.world.entity.Display;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityTypes;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.world.phys.Vec3;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.entity.Display;
-import org.bukkit.util.Transformation;
-import org.joml.AxisAngle4f;
+import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.joml.Quaternionf;
 import org.joml.Vector3f;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class TextDisplay {
 
-    private org.bukkit.entity.TextDisplay entity;
+    private final Set<UUID> viewerList = new HashSet<>();
+    private final Display.TextDisplay textDisplay;
     private Location location;
 
     public TextDisplay(Component text, Location location, Vector3f scale) {
-        this.location = at90(location);
-        sync(() -> {
-            keepChunkLoaded(this.location);
-            entity = this.location.getWorld().spawn(this.location, org.bukkit.entity.TextDisplay.class, display -> {
-                display.text(text);
-                display.setBillboard(Display.Billboard.VERTICAL);
-                display.setBrightness(new Display.Brightness(15, 15));
-                display.setViewRange(2.0f);
-                display.setTransformation(new Transformation(new Vector3f(), new AxisAngle4f(), scale, new AxisAngle4f()));
-                display.setPersistent(false);
-            });
-        });
+        this.location = location;
+        textDisplay = new Display.TextDisplay(EntityTypes.TEXT_DISPLAY, ((CraftWorld) location.getWorld()).getHandle());
+        textDisplay.setPos(location.getX(), location.getY(), location.getZ());
+        textDisplay.setRot(location.getYaw(), location.getPitch());
+        textDisplay.setBillboardConstraints(Display.BillboardConstraints.CENTER);
+        textDisplay.getEntityData().set(new EntityDataAccessor<>(24, EntityDataSerializers.INT), Integer.MAX_VALUE);
+        textDisplay.setInvisible(true);
+        textDisplay.setBrightnessOverride(Brightness.FULL_BRIGHT);
+        textDisplay.setTransformation(new Transformation(new Vector3f(), new Quaternionf(), scale, new Quaternionf()));
+        textDisplay.setText(PaperAdventure.asVanilla(text));
+        update();
+        updateViewersList();
+    }
+
+    public Set<Player> getPlayersWithinDistance(double radius) {
+        return location.getWorld().getPlayers().stream()
+                .filter(player -> player.getLocation().distanceSquared(location) <= radius * radius)
+                .collect(Collectors.toSet());
+    }
+
+    private void addViewer(Player viewer) {
+        if (viewerList.contains(viewer.getUniqueId())) return;
+        viewerList.add(viewer.getUniqueId());
+        ServerPlayer nmsViewer = ((CraftPlayer) viewer).getHandle();
+        ClientboundAddEntityPacket addEntityPacket = new ClientboundAddEntityPacket(
+                textDisplay.getId(),
+                textDisplay.getUUID(),
+                textDisplay.getX(),
+                textDisplay.getY(),
+                textDisplay.getZ(),
+                textDisplay.getXRot(),
+                textDisplay.getYRot(),
+                EntityTypes.TEXT_DISPLAY,
+                0,
+                Vec3.ZERO,
+                0
+        );
+        nmsViewer.connection.send(addEntityPacket);
+
+        List<SynchedEntityData.DataValue<?>> dataValues = textDisplay.getEntityData().getNonDefaultValues();
+        if (dataValues == null || dataValues.isEmpty()) return;
+        nmsViewer.connection.send(new ClientboundSetEntityDataPacket(textDisplay.getId(), dataValues));
+    }
+
+    private void addViewers(Collection<Player> viewers) {
+        viewers.forEach(this::addViewer);
+    }
+
+    private void removeViewer(UUID uuid) {
+        viewerList.remove(uuid);
+        Player player = Bukkit.getPlayer(uuid);
+        if (player == null) return;
+        ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
+        nmsPlayer.connection.send(new ClientboundRemoveEntitiesPacket(textDisplay.getId()));
+    }
+
+    private void removeViewers(Collection<UUID> viewers) {
+        viewers.forEach(this::removeViewer);
+    }
+
+    public void updateViewersList() {
+        Set<Player> viewersToKeep = getPlayersWithinDistance(100);
+        Set<UUID> viewersToRemove = new HashSet<>(viewerList);
+        viewersToKeep.forEach(player -> viewersToRemove.remove(player.getUniqueId()));
+        removeViewers(viewersToRemove);
+        addViewers(viewersToKeep);
     }
 
     public void updateText(Component text) {
-        sync(() -> {
-            if (entity != null) entity.text(text);
-        });
+        textDisplay.setText(PaperAdventure.asVanilla(text));
+        update();
     }
 
-    public void setScale(Vector3f scale) {
-        sync(() -> {
-            if (entity == null) return;
-            Transformation t = entity.getTransformation();
-            entity.setTransformation(new Transformation(t.getTranslation(), t.getLeftRotation(), scale, t.getRightRotation()));
-        });
-    }
-
-    public void setLocation(Location location) {
-        Location loc = at90(location);
-        sync(() -> {
-            if (entity == null) {
-                return;
+    public void update() {
+        if (viewerList.isEmpty()) return;
+        List<SynchedEntityData.DataValue<?>> dataValues = textDisplay.getEntityData().getNonDefaultValues();
+        if (dataValues == null || dataValues.isEmpty()) return;
+        ClientboundSetEntityDataPacket entityDataPacket = new ClientboundSetEntityDataPacket(textDisplay.getId(), dataValues);
+        viewerList.forEach(uuid -> {
+            Player viewer = Bukkit.getPlayer(uuid);
+            if (viewer != null) {
+                ((CraftPlayer) viewer).getHandle().connection.send(entityDataPacket);
             }
-            releaseChunk(this.location);
-            this.location = loc;
-            keepChunkLoaded(this.location);
-            entity.teleport(this.location);
         });
-    }
-
-    /** Force le yaw à 90° (pitch 0) pour que l'holo soit toujours orienté pareil. */
-    private static Location at90(Location location) {
-        Location loc = location.clone();
-        loc.setYaw(90f);
-        loc.setPitch(0f);
-        return loc;
     }
 
     public void remove() {
-        sync(() -> {
-            if (entity != null) {
-                entity.remove();
-                entity = null;
+        ClientboundRemoveEntitiesPacket removeEntitiesPacket = new ClientboundRemoveEntitiesPacket(textDisplay.getId());
+        viewerList.forEach(uuid -> {
+            Player viewer = Bukkit.getPlayer(uuid);
+            if (viewer != null) {
+                ((CraftPlayer) viewer).getHandle().connection.send(removeEntitiesPacket);
             }
-            releaseChunk(location);
         });
+        viewerList.clear();
+        textDisplay.remove(Entity.RemovalReason.CHANGED_DIMENSION);
     }
 
-    private static void keepChunkLoaded(Location location) {
-        location.getWorld().addPluginChunkTicket(location.getChunk().getX(), location.getChunk().getZ(), OMCPlugin.getInstance());
+    public void setScale(Vector3f scale) {
+        textDisplay.setTransformation(new Transformation(new Vector3f(), new Quaternionf(), scale, new Quaternionf()));
+        update();
     }
 
-    private static void releaseChunk(Location location) {
-        location.getWorld().removePluginChunkTicket(location.getChunk().getX(), location.getChunk().getZ(), OMCPlugin.getInstance());
-    }
-
-    private static void sync(Runnable action) {
-        if (Bukkit.isPrimaryThread()) action.run();
-        else Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), action);
+    public void setLocation(Location location) {
+        this.location = location;
+        textDisplay.setPos(location.getX(), location.getY(), location.getZ());
+        textDisplay.setRot(location.getYaw(), location.getPitch());
+        ClientboundTeleportEntityPacket teleportEntityPacket = ClientboundTeleportEntityPacket.teleport(
+                textDisplay.getId(),
+                PositionMoveRotation.of(textDisplay),
+                new HashSet<>(),
+                false
+        );
+        viewerList.forEach(uuid -> {
+            Player viewer = Bukkit.getPlayer(uuid);
+            if (viewer != null) {
+                ((CraftPlayer) viewer).getHandle().connection.send(teleportEntityPacket);
+            }
+        });
     }
 }

--- a/src/main/java/fr/openmc/core/utils/world/entities/TextDisplay.java
+++ b/src/main/java/fr/openmc/core/utils/world/entities/TextDisplay.java
@@ -1,169 +1,72 @@
 package fr.openmc.core.utils.world.entities;
 
-import com.mojang.math.Transformation;
-import io.papermc.paper.adventure.PaperAdventure;
+import fr.openmc.core.OMCPlugin;
 import net.kyori.adventure.text.Component;
-import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
-import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
-import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
-import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket;
-import net.minecraft.network.syncher.EntityDataAccessor;
-import net.minecraft.network.syncher.EntityDataSerializers;
-import net.minecraft.network.syncher.SynchedEntityData;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.util.Brightness;
-import net.minecraft.world.entity.*;
-import net.minecraft.world.phys.Vec3;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.CraftWorld;
-import org.bukkit.craftbukkit.entity.CraftPlayer;
-import org.bukkit.entity.Player;
-import org.joml.Quaternionf;
+import org.bukkit.entity.Display;
+import org.bukkit.util.Transformation;
+import org.joml.AxisAngle4f;
 import org.joml.Vector3f;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class TextDisplay {
 
-    // Code pris de l'un de mes plugins et inspiré de HologramLib (Misieur)
-
-    private final Set<UUID> viewerList = new HashSet<>();
-    private final Display.TextDisplay textDisplay;
-    private Location location;
+    private org.bukkit.entity.TextDisplay entity;
 
     public TextDisplay(Component text, Location location, Vector3f scale) {
-        this.location = location;
-
-        textDisplay = new Display.TextDisplay(EntityTypes.TEXT_DISPLAY, ((CraftWorld) location.getWorld()).getHandle());
-        textDisplay.setPos(location.getX(), location.getY(), location.getZ());
-        textDisplay.setRot(location.getYaw(), location.getPitch());
-        textDisplay.setBillboardConstraints(Display.BillboardConstraints.CENTER);
-        textDisplay.getEntityData().set(new EntityDataAccessor<>(24, EntityDataSerializers.INT),Integer.MAX_VALUE);
-        textDisplay.setInvisible(true);
-        textDisplay.setBrightnessOverride(Brightness.FULL_BRIGHT);
-        textDisplay.setTransformation(new Transformation(new Vector3f(), new Quaternionf(), scale, new Quaternionf()));
-        textDisplay.setText(PaperAdventure.asVanilla(text));
-        update();
-        updateViewersList();
-    }
-
-    public Set<Player> getPlayersWithinDistance(double radius) {
-        return location.getWorld().getPlayers().stream()
-                .filter(player -> player.getLocation().distanceSquared(location) <= radius * radius)
-                .collect(Collectors.toSet());
-    }
-
-    private void addViewer(Player viewer) {
-        if (viewerList.contains(viewer.getUniqueId())) return;
-        viewerList.add(viewer.getUniqueId());
-        ServerPlayer nmsViewer = ((CraftPlayer) viewer).getHandle();
-
-        // Add Entity Packet
-        ClientboundAddEntityPacket addEntityPacket = new ClientboundAddEntityPacket(
-                textDisplay.getId(),
-                textDisplay.getUUID(),
-                textDisplay.getX(),
-                textDisplay.getY(),
-                textDisplay.getZ(),
-                textDisplay.getXRot(),
-                textDisplay.getYRot(),
-                EntityTypes.TEXT_DISPLAY,
-                0,
-                Vec3.ZERO,
-                0
-        );
-        nmsViewer.connection.send(addEntityPacket);
-
-        // Entity Data Packet
-        List<SynchedEntityData.DataValue<?>> dataValues = textDisplay.getEntityData().getNonDefaultValues();
-        if (dataValues == null || dataValues.isEmpty()) return;
-        ClientboundSetEntityDataPacket entityDataPacket = new ClientboundSetEntityDataPacket(textDisplay.getId(), textDisplay.getEntityData().getNonDefaultValues());
-        nmsViewer.connection.send(entityDataPacket);
-    }
-
-    private void addViewers(Collection<Player> viewers) {
-        viewers.forEach(this::addViewer);
-    }
-
-    private void removeViewer(UUID uuid) {
-        viewerList.remove(uuid);
-        Player player = Bukkit.getPlayer(uuid);
-        if (player == null) return;
-        ServerPlayer nmsPlayer = ((CraftPlayer) player).getHandle();
-        ClientboundRemoveEntitiesPacket removeEntitiesPacket = new ClientboundRemoveEntitiesPacket(textDisplay.getId());
-        nmsPlayer.connection.send(removeEntitiesPacket);
-    }
-
-    private void removeViewers(Collection<UUID> viewers) {
-        viewers.forEach(this::removeViewer);
-    }
-
-    public void updateViewersList() {
-        Set<Player> viewersToKeep = getPlayersWithinDistance(100);
-
-        Set<UUID> viewersToRemove = new HashSet<>(viewerList);
-        viewersToKeep.forEach(player -> viewersToRemove.remove(player.getUniqueId()));
-
-        removeViewers(viewersToRemove);
-        addViewers(viewersToKeep);
+        Location loc = at90(location);
+        sync(() -> entity = loc.getWorld().spawn(loc, org.bukkit.entity.TextDisplay.class, display -> {
+            display.text(text);
+            display.setBillboard(Display.Billboard.VERTICAL);
+            display.setBrightness(new Display.Brightness(15, 15));
+            display.setViewRange(2.0f);
+            display.setTransformation(new Transformation(new Vector3f(), new AxisAngle4f(), scale, new AxisAngle4f()));
+            //garder les chunks des holo chargés
+            //passer en persistant + tag PDC nettoyé au démarrage si un jour les holo sortent des spawn chunks
+            display.setPersistent(false);
+        }));
     }
 
     public void updateText(Component text) {
-        textDisplay.setText(PaperAdventure.asVanilla(text));
-        update();
-    }
-
-    public void update() {
-        if (viewerList.isEmpty()) return;
-        List<SynchedEntityData.DataValue<?>> dataValues = textDisplay.getEntityData().getNonDefaultValues();
-        if (dataValues == null || dataValues.isEmpty()) return;
-        ClientboundSetEntityDataPacket entityDataPacket = new ClientboundSetEntityDataPacket(textDisplay.getId(), textDisplay.getEntityData().getNonDefaultValues());
-        viewerList.forEach(uuid -> {
-            Player viewer = Bukkit.getPlayer(uuid);
-            if (viewer != null) {
-                ServerPlayer nmsViewer = ((CraftPlayer) viewer).getHandle();
-                nmsViewer.connection.send(entityDataPacket);
-            }
+        sync(() -> {
+            if (entity != null) entity.text(text);
         });
-    }
-
-    public void remove() {
-        ClientboundRemoveEntitiesPacket removeEntitiesPacket = new ClientboundRemoveEntitiesPacket(textDisplay.getId());
-        viewerList.forEach(uuid -> {
-            Player viewer = Bukkit.getPlayer(uuid);
-            if (viewer != null) {
-                ServerPlayer player = ((CraftPlayer) viewer).getHandle();
-                player.connection.send(removeEntitiesPacket);
-            }
-        });
-        viewerList.clear();
-        textDisplay.remove(Entity.RemovalReason.CHANGED_DIMENSION);
     }
 
     public void setScale(Vector3f scale) {
-        textDisplay.setTransformation(new Transformation(new Vector3f(), new Quaternionf(), scale, new Quaternionf()));
-        update();
+        sync(() -> {
+            if (entity == null) return;
+            Transformation t = entity.getTransformation();
+            entity.setTransformation(new Transformation(t.getTranslation(), t.getLeftRotation(), scale, t.getRightRotation()));
+        });
     }
 
     public void setLocation(Location location) {
-        this.location = location;
-        textDisplay.setPos(location.getX(), location.getY(), location.getZ());
-        textDisplay.setRot(location.getYaw(), location.getPitch());
-        ClientboundTeleportEntityPacket teleportEntityPacket = ClientboundTeleportEntityPacket.teleport(
-                textDisplay.getId(),
-                PositionMoveRotation.of(textDisplay),
-                new HashSet<>(),
-                false
-        );
-        viewerList.forEach(uuid -> {
-            Player viewer = Bukkit.getPlayer(uuid);
-            if (viewer != null) {
-                ServerPlayer nmsViewer = ((CraftPlayer) viewer).getHandle();
-                nmsViewer.connection.send(teleportEntityPacket);
+        Location loc = at90(location);
+        sync(() -> {
+            if (entity != null) entity.teleport(loc);
+        });
+    }
+
+    /** Force le yaw à 90° (pitch 0) pour que l'holo soit toujours orienté pareil. */
+    private static Location at90(Location location) {
+        Location loc = location.clone();
+        loc.setYaw(90f);
+        loc.setPitch(0f);
+        return loc;
+    }
+
+    public void remove() {
+        sync(() -> {
+            if (entity != null) {
+                entity.remove();
+                entity = null;
             }
         });
     }
 
+    private static void sync(Runnable action) {
+        if (Bukkit.isPrimaryThread()) action.run();
+        else Bukkit.getScheduler().runTask(OMCPlugin.getInstance(), action);
+    }
 }


### PR DESCRIPTION
## Petit résumé de la PR:

Cette PR conserve les hologrammes virtuels NMS et corrige leur cycle de viewers. Les chunks ne sont pas forcés à rester chargés.

## Étape nécessaire afin que la PR soit fini (si PR en draft)

- [ ] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [ ] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : #1265

## Decrivez vos changements

- Les `TextDisplay` restent des hologrammes virtuels NMS envoyés par paquets aux joueurs proches.
- La liste des viewers est de nouveau actualisée régulièrement : les hologrammes réapparaissent après une reconnexion.
- `/leaderboard setPos` sauvegarde la position dans `leaderboards.yml`, recharge la configuration et envoie le déplacement de l’hologramme actuel aux viewers.
- Les textes legacy des hologrammes sont désérialisés avant leur création pour supprimer les warnings Adventure concernés.