### PR TITLE
Correctif d'un soucis d'écriture de fichiers pour les ambiences

### DIFF
--- a/src/main/java/fr/openmc/api/datapacks/injectors/BiomesInjector.java
+++ b/src/main/java/fr/openmc/api/datapacks/injectors/BiomesInjector.java
@@ -47,6 +47,7 @@ public class BiomesInjector implements DatapackInjector {
             Files.createDirectories(root);
             for (var entry : entries.entrySet()) {
                 Path biomeFile = root.resolve(entry.getKey() + ".json");
+                Files.createDirectories(biomeFile.getParent());
                 Files.writeString(biomeFile, GSON.toJson(entry.getValue().toJson()));
             }
         } catch (IOException e) {

--- a/src/main/java/fr/openmc/api/datapacks/injectors/DimensionTypesInjector.java
+++ b/src/main/java/fr/openmc/api/datapacks/injectors/DimensionTypesInjector.java
@@ -45,6 +45,7 @@ public class DimensionTypesInjector implements DatapackInjector {
             Files.createDirectories(root);
             for (var entry : entries.entrySet()) {
                 Path dimensionTypeFile = root.resolve(entry.getKey() + ".json");
+                Files.createDirectories(dimensionTypeFile.getParent());
                 Files.writeString(dimensionTypeFile, GSON.toJson(entry.getValue().toJson()));
             }
         } catch (IOException e) {

--- a/src/main/java/fr/openmc/api/datapacks/injectors/TimelinesInjector.java
+++ b/src/main/java/fr/openmc/api/datapacks/injectors/TimelinesInjector.java
@@ -51,6 +51,7 @@ public class TimelinesInjector implements DatapackInjector {
             Files.createDirectories(root);
             for (var entry : entries.entrySet()) {
                 Path file = root.resolve(entry.getKey() + ".json");
+                Files.createDirectories(file.getParent());
                 Files.writeString(file, GSON.toJson(entry.getValue().toJson()));
             }
         } catch (IOException e) {


### PR DESCRIPTION
## Petit résumé de la PR:
Résumé court: avec les biomes customs terralith fait des dossiers pour mettre les biomes (ex cave) mais le programme n'est pas conçu pour faire les dossiers si besoin. donc il tente d'écrire quelque part ou il ne peut pas

## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [x] Bien documenter la feature
- [x] Fournir un profileur (si besoin/demandé par un admin)
- [x] Avoir une milestone associée à la PR
- [x] Valider tout les checks
- [x] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->
