### PR TITLE
Correctif des Elevateurs avec un bloc au dessus

### DIFF
--- a/src/main/java/fr/openmc/core/features/itemsadder/elevator/ElevatorBlockListener.java
+++ b/src/main/java/fr/openmc/core/features/itemsadder/elevator/ElevatorBlockListener.java
@@ -9,7 +9,6 @@ import fr.openmc.core.utils.text.messages.MessageType;
 import fr.openmc.core.utils.text.messages.MessagesManager;
 import fr.openmc.core.utils.text.messages.Prefix;
 import fr.openmc.core.utils.text.messages.TranslationManager;
-import fr.openmc.core.utils.world.LocationUtils;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -32,6 +31,12 @@ public class ElevatorBlockListener implements Listener {
 
         if (!ElevatorManager.isOnTop(player)) return;
 
+        if (!ElevatorManager.isSafeGround(player.getLocation()))  {
+            MessagesManager.sendMessage(offlinePlayer, TranslationManager.translation("messages.elevator.obstructed_1"),
+                    Prefix.OPENMC, MessageType.WARNING, true);
+            return;
+        }
+
         Location locAfterTP = ElevatorManager.getNextTop(player);
 
         if (locAfterTP.equals(player.getLocation())) {
@@ -40,8 +45,8 @@ public class ElevatorBlockListener implements Listener {
             return;
         }
 
-        if (!LocationUtils.isSafeGround(locAfterTP)) {
-            MessagesManager.sendMessage(offlinePlayer, TranslationManager.translation("messages.elevator.obstructed"),
+        if (!ElevatorManager.isSafeGround(locAfterTP)) {
+            MessagesManager.sendMessage(offlinePlayer, TranslationManager.translation("messages.elevator.obstructed_0"),
                     Prefix.OPENMC, MessageType.WARNING, true);
             return;
         }
@@ -56,6 +61,12 @@ public class ElevatorBlockListener implements Listener {
 
         if (!ElevatorManager.isOnTop(player)) return;
 
+        if (!ElevatorManager.isSafeGround(player.getLocation()))  {
+            MessagesManager.sendMessage(offlinePlayer, TranslationManager.translation("messages.elevator.obstructed_1"),
+                    Prefix.OPENMC, MessageType.WARNING, true);
+            return;
+        }
+
         if (event.isSneaking()) return;
 
         Location locAfterTP = ElevatorManager.getNextDown(player);
@@ -66,8 +77,8 @@ public class ElevatorBlockListener implements Listener {
             return;
         }
 
-        if (!LocationUtils.isSafeGround(locAfterTP)) {
-            MessagesManager.sendMessage(offlinePlayer, TranslationManager.translation("messages.elevator.obstructed"),
+        if (!ElevatorManager.isSafeGround(locAfterTP)) {
+            MessagesManager.sendMessage(offlinePlayer, TranslationManager.translation("messages.elevator.obstructed_0"),
                     Prefix.OPENMC, MessageType.WARNING, true);
             return;
         }

--- a/src/main/java/fr/openmc/core/features/itemsadder/elevator/ElevatorManager.java
+++ b/src/main/java/fr/openmc/core/features/itemsadder/elevator/ElevatorManager.java
@@ -5,7 +5,11 @@ import dev.lone.itemsadder.api.CustomStack;
 import fr.openmc.core.bootstrap.features.Feature;
 import fr.openmc.core.bootstrap.features.annotations.Credit;
 import fr.openmc.core.bootstrap.features.types.HasListeners;
+import fr.openmc.core.utils.world.LocationUtils;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Tag;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -161,6 +165,29 @@ public class ElevatorManager extends Feature implements HasListeners {
     public static boolean isElevator(CustomStack item) {
         if (item == null) return false;
         return isElevator(item.getNamespacedID());
+    }
+
+    public static boolean isSafeGround(Location loc) {
+        World world = loc.getWorld();
+        Block above = world.getBlockAt(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+
+        if (Tag.WOOL_CARPETS.isTagged(above.getType())
+                || Tag.BUTTONS.isTagged(above.getType())
+                || Tag.PRESSURE_PLATES.isTagged(above.getType())
+                || Tag.BANNERS.isTagged(above.getType())
+                || Tag.SIGNS.isTagged(above.getType())
+                || Tag.FLOWERS.isTagged(above.getType())) return true;
+
+        if (above.getType() == Material.MOSS_CARPET
+                || above.getType() == Material.PALE_MOSS_CARPET
+                || above.getType() == Material.SCULK_VEIN) return true;
+
+        return !above.isSolid()
+                && above.isPassable()
+                && !above.isLiquid()
+                && above.getType() != Material.LAVA
+                && above.getType() != Material.CACTUS
+                && above.getType() != Material.MAGMA_BLOCK;
     }
 
     @Override

--- a/src/main/resources/translations/default/main.properties
+++ b/src/main/resources/translations/default/main.properties
@@ -36,7 +36,7 @@ messages.menus.none=<gray>Aucun</gray>
 messages.elevator.limit.up=Vous ne pouvez pas aller plus haut !
 messages.elevator.limit.down=Vous ne pouvez pas aller plus bas !
 messages.elevator.obstructed_0=Prochaine étage obstrué !
-messages.elevator.obstructed_1=étage actuel obstrué !
+messages.elevator.obstructed_1=Étage actuel obstrué !
 
 registries.menu.lootbox.name=<gray>Lootbox</gray>
 registries.menu.chance=<gray>Chance :</gray> %1$s

--- a/src/main/resources/translations/default/main.properties
+++ b/src/main/resources/translations/default/main.properties
@@ -35,7 +35,8 @@ messages.menus.none=<gray>Aucun</gray>
 
 messages.elevator.limit.up=Vous ne pouvez pas aller plus haut !
 messages.elevator.limit.down=Vous ne pouvez pas aller plus bas !
-messages.elevator.obstructed=Prochaine étage obstrué !
+messages.elevator.obstructed_0=Prochaine étage obstrué !
+messages.elevator.obstructed_1=étage actuel obstrué !
 
 registries.menu.lootbox.name=<gray>Lootbox</gray>
 registries.menu.chance=<gray>Chance :</gray> %1$s

--- a/src/main/resources/translations/en_GB/main.properties
+++ b/src/main/resources/translations/en_GB/main.properties
@@ -32,7 +32,8 @@ messages.menus.none=<gray>None</gray>
 
 messages.elevator.limit.up=You can't go any higher !
 messages.elevator.limit.down=You can't go any lower !
-messages.elevator.obstructed=Next floor obstructed !
+messages.elevator.obstructed_0=Next floor obstructed !
+messages.elevator.obstructed_1=Current floor obstructed !
 
 registries.menu.lootbox.name=<gray>Lootbox</gray>
 registries.menu.chance=<gray>Chance :</gray> %1$s

--- a/src/main/resources/translations/en_US/main.properties
+++ b/src/main/resources/translations/en_US/main.properties
@@ -32,7 +32,8 @@ messages.menus.none=<gray>None</gray>
 
 messages.elevator.limit.up=You can't go any higher !
 messages.elevator.limit.down=You can't go any lower !
-messages.elevator.obstructed=Next floor obstructed !
+messages.elevator.obstructed_0=Next floor obstructed !
+messages.elevator.obstructed_1=Current floor obstructed !
 
 registries.menu.lootbox.name=<gray>Lootbox</gray>
 registries.menu.chance=<gray>Chance :</gray> %1$s


### PR DESCRIPTION
## Petit résumé de la PR:
Faire en sorte de pouvoir descendre / monter un elevator si il y a un block sans collision ou des carpets

## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [x] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [x] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 
#1407 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->

Ajout d'un nouveau message pour dire que l'étage actuel est obstrué, et modification du check du block du prochaine étage / étage actuel
