### PR TITLE
Correctif du craft du pain

### DIFF
--- a/src/main/resources/contents/omc_daily_events/golden_crops.yml
+++ b/src/main/resources/contents/omc_daily_events/golden_crops.yml
@@ -48,7 +48,7 @@ items:
       generate: true
       textures:
         - golden_crops/golden_beetroot
-      material: BEETROOT
+      material: PAPER
     lore:
       - <lang:itemsadder.omc_daily_events.golden_beetroot.lore.0>
 
@@ -58,7 +58,7 @@ items:
       generate: true
       textures:
         - golden_crops/golden_potato
-      material: POTATO
+      material: PAPER
     lore:
       - <lang:itemsadder.omc_daily_events.golden_potato.lore.0>
 
@@ -68,7 +68,7 @@ items:
       generate: true
       textures:
         - golden_crops/golden_wheat
-      material: WHEAT
+      material: PAPER
     lore:
       - <lang:itemsadder.omc_daily_events.golden_wheat.lore.0>
 
@@ -78,6 +78,6 @@ items:
       generate: true
       textures:
         - golden_crops/really_golden_carrot
-      material: CARROT
+      material: PAPER
     lore:
       - <lang:itemsadder.omc_daily_events.really_golden_carrot.lore.0>


### PR DESCRIPTION
## Petit résumé de la PR:
Le bug provient d'ItemsAdderAdditions qui annule tt les autres crafts comme mon craft de pain béni utilisait des materials WHEAT, j'ai remplacé par du PAPER au moins plus de soucis


## Étape nécessaire afin que la PR soit fini (si PR en draft)
<!-- *mettez des checkbox `- []` et les cocher lorsque les taches sont finies* -->
<!-- *ex. - [] Enlever tous les imports non utilisés* -->

- [ ] Suivre le [Code de Conduite](https://github.com/ServerOpenMC/PluginV2/blob/master/CODE_OF_CONDUCT.md)
- [ ] Enlever tous les imports non utilisés
- [ ] Bien documenter la feature
- [ ] Fournir un profileur (si besoin/demandé par un admin)
- [ ] Avoir une milestone associée à la PR
- [ ] Valider tout les checks
- [ ] Tester et valider la feature/changement

* Les Issues corrigée(s) en commun : 

## Decrivez vos changements
<!-- *Clairement et avec des screenshots si nécessaires* -->
